### PR TITLE
Make sure the socket gets reopen when an exception is triggered

### DIFF
--- a/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
+++ b/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard1.3;net451</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.Datadog.Logs</AssemblyName>
     <PackageId>Serilog.Sinks.Datadog.Logs</PackageId>
-    <PackageVersion>0.1.5</PackageVersion>
+    <PackageVersion>0.1.4</PackageVersion>
     <Authors>Datadog</Authors>
     <Title>Serilog Sink Datadog Logs</Title>
     <Description>Serilog Sink that sends log events to Datadog https://www.datadoghq.com/</Description>

--- a/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
+++ b/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
@@ -4,7 +4,7 @@
     <TargetFrameworks>netstandard2.0;netstandard1.3;net451</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.Datadog.Logs</AssemblyName>
     <PackageId>Serilog.Sinks.Datadog.Logs</PackageId>
-    <PackageVersion>0.1.4</PackageVersion>
+    <PackageVersion>0.1.5</PackageVersion>
     <Authors>Datadog</Authors>
     <Title>Serilog Sink Datadog Logs</Title>
     <Description>Serilog Sink that sends log events to Datadog https://www.datadoghq.com/</Description>

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogClient.cs
@@ -98,6 +98,7 @@ namespace Serilog.Sinks.Datadog.Logs
                 }
                 catch (Exception e)
                 {
+                    _stream.Close();
                     SelfLog.WriteLine("Could not send data to Datadog: {0}", e);
                 }
             }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogClient.cs
@@ -62,6 +62,23 @@ namespace Serilog.Sinks.Datadog.Logs
             }
         }
 
+        private void CloseConnection()
+        {
+            _stream.Close();
+            _stream = null;
+#if NETSTANDARD1_3
+            _client.Dispose();
+#else
+            _client.Close();
+#endif
+            _client = null;
+        }
+
+        private bool IsConnectionClosed()
+        {
+            return _client == null || _stream == null;
+        }
+
         /// <summary>
         /// Send payload to Datadog logs-backend.
         /// </summary>
@@ -76,7 +93,7 @@ namespace Serilog.Sinks.Datadog.Logs
                     await Task.Delay(backoff * 1000);
                 }
 
-                if (_client == null || _client.Connected == false)
+                if (IsConnectionClosed())
                 {
                     try
                     {
@@ -98,7 +115,7 @@ namespace Serilog.Sinks.Datadog.Logs
                 }
                 catch (Exception e)
                 {
-                    _stream.Close();
+                    CloseConnection();
                     SelfLog.WriteLine("Could not send data to Datadog: {0}", e);
                 }
             }
@@ -110,22 +127,17 @@ namespace Serilog.Sinks.Datadog.Logs
         /// </summary>
         public void Close()
         {
-            if (_client != null)
+            if (!IsConnectionClosed())
             {
                 try
                 {
                     _stream.Flush();
-#if NETSTANDARD1_3
-                    _client.Dispose();
-#else
-                    _client.Close();
-#endif
-                    _client = null;
                 }
                 catch (Exception e)
                 {
-                    SelfLog.WriteLine("Could not close the client: {0}", e);
+                    SelfLog.WriteLine("Could not flush the remaining data: {0}", e);
                 }
+                CloseConnection();
             }
         }
     }


### PR DESCRIPTION
### What does this PR do?

Properly close a socket when an exception is triggered when attempting to send data.

### Motivation

Fix a bug that would lead to stop sending logs until restart of the application when an exception is triggered on write.

### Additional Notes

This should fix https://github.com/DataDog/serilog-sinks-datadog-logs/issues/8 and probably https://github.com/DataDog/serilog-sinks-datadog-logs/issues/4