### PR TITLE
Handle remote disconnection

### DIFF
--- a/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
+++ b/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
@@ -19,6 +19,7 @@
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.1.1" />
     <PackageReference Include="Serilog" Version="2.7.1" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
+    <PackageReference Include="System.Net.NetworkInformation" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
This is to fix an issue where after the remote Datadog log intake server disconnects after 1 minute of inactivity, subsequent messages sent can be lost until dotnet notices the connection is broken and throws the appropriate exception.

Fixes https://github.com/DataDog/serilog-sinks-datadog-logs/issues/21