### PR TITLE
Properly handle server close in TCP client

### DIFF
--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogClient.cs
@@ -112,6 +112,11 @@ namespace Serilog.Sinks.Datadog.Logs
                     SelfLog.WriteLine("Sending payload to Datadog: {0}", payload);
                     byte[] data = UTF8.GetBytes(payload);
                     _stream.Write(data, 0, data.Length);
+                    if (!_client.Connected) {
+                        SelfLog.WriteLine("Could not send data to Datadog: connection is closed");
+                        CloseConnection();
+                        continue;
+                    }
                     return;
                 }
                 catch (Exception e)


### PR DESCRIPTION
### What does this PR do?

Make sure data has been sent on each write by checking that the client is still connected, if not, retry.

### Motivation

Properly handle remote close

### Additional Notes

https://github.com/DataDog/serilog-sinks-datadog-logs/issues/21
