### PR TITLE
Remove SelfLog.WriteLine in cases where no error occured.

### DIFF
--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
@@ -46,7 +46,6 @@ namespace Serilog.Sinks.Datadog.Logs
             _client = new HttpClient();
             _url = $"{config.Url}/v1/input/{apiKey}";
             _formatter = formatter;
-            SelfLog.WriteLine("Creating HTTP client with config: {0}", config);
         }
 
         public async Task WriteAsync(IEnumerable<LogEvent> events)
@@ -106,9 +105,7 @@ namespace Serilog.Sinks.Datadog.Logs
 
                 try
                 {
-                    SelfLog.WriteLine("Sending payload to Datadog: {0}", payload);
                     var result = await _client.PostAsync(_url, content);
-                    SelfLog.WriteLine("Statuscode: {0}", result.StatusCode);
                     if (result == null) { continue; }
                     if ((int)result.StatusCode >= 500) { continue; }
                     if ((int)result.StatusCode >= 400) { break; }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogTcpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogTcpClient.cs
@@ -56,7 +56,6 @@ namespace Serilog.Sinks.Datadog.Logs
             _config = config;
             _formatter = formatter;
             _apiKey = apiKey;
-            SelfLog.WriteLine("Creating TCP client with config: {0}", config);
         }
 
         /// <summary>
@@ -113,7 +112,6 @@ namespace Serilog.Sinks.Datadog.Logs
 
                 try
                 {
-                    SelfLog.WriteLine("Sending payload to Datadog: {0}", payload);
                     byte[] data = UTF8.GetBytes(payload);
                     _stream.Write(data, 0, data.Length);
                     return;


### PR DESCRIPTION
The sink is quite chatty to the console. However SelfLog should only be used in cases of problems/errors. That is the case in other serilog sinks.