### PR TITLE
Allow batch size, period and queue limit to be set

### DIFF
--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -27,7 +27,7 @@ namespace Serilog
         /// <param name="tags">Custom tags.</param>
         /// <param name="configuration">The Datadog logs client configuration.</param>
         /// <param name="configurationSection">A config section defining the datadog configuration.</param>
-        /// <param name="restrictedToMinimumLevel">The minimum log level for the sink.</param>
+        /// <param name="logLevel">The minimum log level for the sink.</param>
         /// <param name="batchSizeLimit">The maximum number of events to emit in a single batch.</param>
         /// <param name="batchPeriod">The time to wait before emitting a new event batch.</param>
         /// <param name="queueLimit">
@@ -45,7 +45,7 @@ namespace Serilog
             string[] tags = null,
             DatadogConfiguration configuration = null,
             IConfigurationSection configurationSection = null,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LogEventLevel logLevel = LevelAlias.Minimum,
             int? batchSizeLimit = null,
             TimeSpan? batchPeriod = null,
             int? queueLimit = null)
@@ -62,7 +62,7 @@ namespace Serilog
             var config = ApplyMicrosoftExtensionsConfiguration.ConfigureDatadogConfiguration(configuration, configurationSection);
             var sink = DatadogSink.Create(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, queueLimit);
 
-            return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);
+            return loggerConfiguration.Sink(sink, logLevel);
         }
     }
 }

--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -27,6 +27,13 @@ namespace Serilog
         /// <param name="tags">Custom tags.</param>
         /// <param name="configuration">The Datadog logs client configuration.</param>
         /// <param name="configurationSection">A config section defining the datadog configuration.</param>
+        /// <param name="logLevel">The minimum log level for the sink.</param>
+        /// <param name="batchSizeLimit">The maximum number of events to emit in a single batch.</param>
+        /// <param name="batchPeriod">The time to wait before emitting a new event batch.</param>
+        /// <param name="queueLimit">
+        /// Maximum number of events to hold in the sink's internal queue, or <c>null</c>
+        /// for an unbounded queue. The default is <c>10000</c>
+        /// </param>
         /// <returns>Logger configuration</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration DatadogLogs(
@@ -38,7 +45,10 @@ namespace Serilog
             string[] tags = null,
             DatadogConfiguration configuration = null,
             IConfigurationSection configurationSection = null,
-            LogEventLevel logLevel = LevelAlias.Minimum)
+            LogEventLevel logLevel = LevelAlias.Minimum,
+            int? batchSizeLimit = null,
+            TimeSpan? batchPeriod = null,
+            int? queueLimit = null)
         {
             if (loggerConfiguration == null)
             {
@@ -50,8 +60,9 @@ namespace Serilog
             }
 
             var config = ApplyMicrosoftExtensionsConfiguration.ConfigureDatadogConfiguration(configuration, configurationSection);
+            var sink = DatadogSink.Create(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, queueLimit);
 
-            return loggerConfiguration.Sink(new DatadogSink(apiKey, source, service, host, tags, config), logLevel);
+            return loggerConfiguration.Sink(sink);
         }
     }
 }

--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -27,7 +27,7 @@ namespace Serilog
         /// <param name="tags">Custom tags.</param>
         /// <param name="configuration">The Datadog logs client configuration.</param>
         /// <param name="configurationSection">A config section defining the datadog configuration.</param>
-        /// <param name="logLevel">The minimum log level for the sink.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log level for the sink.</param>
         /// <param name="batchSizeLimit">The maximum number of events to emit in a single batch.</param>
         /// <param name="batchPeriod">The time to wait before emitting a new event batch.</param>
         /// <param name="queueLimit">
@@ -45,7 +45,7 @@ namespace Serilog
             string[] tags = null,
             DatadogConfiguration configuration = null,
             IConfigurationSection configurationSection = null,
-            LogEventLevel logLevel = LevelAlias.Minimum,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             int? batchSizeLimit = null,
             TimeSpan? batchPeriod = null,
             int? queueLimit = null)
@@ -62,7 +62,7 @@ namespace Serilog
             var config = ApplyMicrosoftExtensionsConfiguration.ConfigureDatadogConfiguration(configuration, configurationSection);
             var sink = DatadogSink.Create(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, queueLimit);
 
-            return loggerConfiguration.Sink(sink);
+            return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);
         }
     }
 }

--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/System.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/System.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -25,7 +25,7 @@ namespace Serilog
         /// <param name="host">The host name.</param>
         /// <param name="tags">Custom tags.</param>
         /// <param name="configuration">The Datadog logs client configuration.</param>
-        /// <param name="restrictedToMinimumLevel">The minimum log level for the sink.</param>
+        /// <param name="logLevel">The minimum log level for the sink.</param>
         /// <param name="batchSizeLimit">The maximum number of events to emit in a single batch.</param>
         /// <param name="batchPeriod">The time to wait before emitting a new event batch.</param>
         /// <param name="queueLimit">
@@ -42,7 +42,7 @@ namespace Serilog
             string host = null,
             string[] tags = null,
             DatadogConfiguration configuration = null,
-            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LogEventLevel logLevel = LevelAlias.Minimum,
             int? batchSizeLimit = null,
             TimeSpan? batchPeriod = null,
             int? queueLimit = null)
@@ -59,7 +59,7 @@ namespace Serilog
             configuration = (configuration != null) ? configuration : new DatadogConfiguration();
             var sink = DatadogSink.Create(apiKey, source, service, host, tags, configuration, batchSizeLimit, batchPeriod, queueLimit);
 
-            return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);
+            return loggerConfiguration.Sink(sink, logLevel);
         }
     }
 }

--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/System.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/System.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -25,6 +25,13 @@ namespace Serilog
         /// <param name="host">The host name.</param>
         /// <param name="tags">Custom tags.</param>
         /// <param name="configuration">The Datadog logs client configuration.</param>
+        /// <param name="logLevel">The minimum log level for the sink.</param>
+        /// <param name="batchSizeLimit">The maximum number of events to emit in a single batch.</param>
+        /// <param name="batchPeriod">The time to wait before emitting a new event batch.</param>
+        /// <param name="queueLimit">
+        /// Maximum number of events to hold in the sink's internal queue, or <c>null</c>
+        /// for an unbounded queue. The default is <c>10000</c>
+        /// </param>
         /// <returns>Logger configuration</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration DatadogLogs(
@@ -35,7 +42,10 @@ namespace Serilog
             string host = null,
             string[] tags = null,
             DatadogConfiguration configuration = null,
-            LogEventLevel logLevel = LevelAlias.Minimum)
+            LogEventLevel logLevel = LevelAlias.Minimum,
+            int? batchSizeLimit = null,
+            TimeSpan? batchPeriod = null,
+            int? queueLimit = null)
         {
             if (loggerConfiguration == null)
             {
@@ -47,7 +57,9 @@ namespace Serilog
             }
 
             configuration = (configuration != null) ? configuration : new DatadogConfiguration();
-            return loggerConfiguration.Sink(new DatadogSink(apiKey, source, service, host, tags, configuration), logLevel);
+            var sink = DatadogSink.Create(apiKey, source, service, host, tags, configuration, batchSizeLimit, batchPeriod, queueLimit);
+
+            return loggerConfiguration.Sink(sink);
         }
     }
 }

--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/System.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/System.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -25,7 +25,7 @@ namespace Serilog
         /// <param name="host">The host name.</param>
         /// <param name="tags">Custom tags.</param>
         /// <param name="configuration">The Datadog logs client configuration.</param>
-        /// <param name="logLevel">The minimum log level for the sink.</param>
+        /// <param name="restrictedToMinimumLevel">The minimum log level for the sink.</param>
         /// <param name="batchSizeLimit">The maximum number of events to emit in a single batch.</param>
         /// <param name="batchPeriod">The time to wait before emitting a new event batch.</param>
         /// <param name="queueLimit">
@@ -42,7 +42,7 @@ namespace Serilog
             string host = null,
             string[] tags = null,
             DatadogConfiguration configuration = null,
-            LogEventLevel logLevel = LevelAlias.Minimum,
+            LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
             int? batchSizeLimit = null,
             TimeSpan? batchPeriod = null,
             int? queueLimit = null)
@@ -59,7 +59,7 @@ namespace Serilog
             configuration = (configuration != null) ? configuration : new DatadogConfiguration();
             var sink = DatadogSink.Create(apiKey, source, service, host, tags, configuration, batchSizeLimit, batchPeriod, queueLimit);
 
-            return loggerConfiguration.Sink(sink);
+            return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);
         }
     }
 }

--- a/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
+++ b/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.3;</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.3;net45</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.Datadog.Logs</AssemblyName>
     <PackageId>Serilog.Sinks.Datadog.Logs</PackageId>
     <PackageVersion>0.3.1</PackageVersion>

--- a/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
+++ b/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.3;</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.Datadog.Logs</AssemblyName>
     <PackageId>Serilog.Sinks.Datadog.Logs</PackageId>
     <PackageVersion>0.3.1</PackageVersion>

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -38,12 +38,6 @@ namespace Serilog.Sinks.Datadog.Logs
         /// </summary>
         private const int DefaultBatchSizeLimit = 50;
 
-        /// <summary>
-        /// Maximum number of events to hold in the sink's internal queue, or <c>null</c>
-        /// for an unbounded queue. The default is <c>10000</c>.
-        /// </summary>
-        private const int DefaultQueueLimit = 10000;
-
         public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int? batchSizeLimit = null, TimeSpan? batchPeriod = null)
             : base(batchSizeLimit ?? DefaultBatchSizeLimit, batchPeriod ?? DefaultBatchPeriod)
         {
@@ -57,8 +51,8 @@ namespace Serilog.Sinks.Datadog.Logs
             }
         }
 
-        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, int? queueLimit = null)
-            : base(batchSizeLimit ?? DefaultBatchSizeLimit, batchPeriod ?? DefaultBatchPeriod, queueLimit ?? DefaultQueueLimit)
+        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int queueLimit, int? batchSizeLimit = null, TimeSpan? batchPeriod = null)
+            : base(batchSizeLimit ?? DefaultBatchSizeLimit, batchPeriod ?? DefaultBatchPeriod, queueLimit)
         {
             if (config.UseTCP)
             {
@@ -73,7 +67,7 @@ namespace Serilog.Sinks.Datadog.Logs
         public static DatadogSink Create(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, int? queueLimit = null)
         {
             if (queueLimit.HasValue)
-                return new DatadogSink(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, queueLimit);
+                return new DatadogSink(apiKey, source, service, host, tags, config, queueLimit.Value, batchSizeLimit, batchPeriod);
 
             return new DatadogSink(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod);
         }


### PR DESCRIPTION
This PR extends the sink to allow the batch size, period and queue limit to be set. Previously these were hardcoded values which we found unsuitable for a number of applications generating a large number of log entries. 

I'm still not 100% sure how configuration (e.g. appsettings.json) is auto-magically bound to the sink so have just followed the existing conventions.

Note that I had to use two constructors since the periodic batching only allows a queue limit to either be set or not (resulting in an unbound queue).

There's a couple of unreferenced JSON related fields which I look like they could be removed but again I'm unaware of they're being used for any dynamic binding.