### PR TITLE
Add callback on error

### DIFF
--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -34,6 +34,7 @@ namespace Serilog
         /// Maximum number of events to hold in the sink's internal queue, or <c>null</c>
         /// for an unbounded queue. The default is <c>10000</c>
         /// </param>
+        /// <param name="exceptionHandler">This function is called when an exception occurs.</param>
         /// <returns>Logger configuration</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration DatadogLogs(
@@ -48,7 +49,8 @@ namespace Serilog
             LogEventLevel logLevel = LevelAlias.Minimum,
             int? batchSizeLimit = null,
             TimeSpan? batchPeriod = null,
-            int? queueLimit = null)
+            int? queueLimit = null,
+            Action<Exception> exceptionHandler = null)
         {
             if (loggerConfiguration == null)
             {
@@ -60,7 +62,7 @@ namespace Serilog
             }
 
             var config = ApplyMicrosoftExtensionsConfiguration.ConfigureDatadogConfiguration(configuration, configurationSection);
-            var sink = DatadogSink.Create(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, queueLimit);
+            var sink = DatadogSink.Create(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, queueLimit, exceptionHandler);
 
             return loggerConfiguration.Sink(sink, logLevel);
         }

--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -34,7 +34,8 @@ namespace Serilog
         /// Maximum number of events to hold in the sink's internal queue, or <c>null</c>
         /// for an unbounded queue. The default is <c>10000</c>
         /// </param>
-        /// <param name="exceptionHandler">This function is called when an exception occurs.</param>
+        /// <param name="exceptionHandler">This function is called when an exception occurs when using 
+        /// DatadogConfiguration.UseTCP=false (the default configuration)</param>
         /// <returns>Logger configuration</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration DatadogLogs(

--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/System.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/System.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -32,6 +32,8 @@ namespace Serilog
         /// Maximum number of events to hold in the sink's internal queue, or <c>null</c>
         /// for an unbounded queue. The default is <c>10000</c>
         /// </param>
+        /// <param name="exceptionHandler">This function is called when an exception occurs when using 
+        /// DatadogConfiguration.UseTCP=false (the default configuration)</param>
         /// <returns>Logger configuration</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration DatadogLogs(
@@ -45,7 +47,8 @@ namespace Serilog
             LogEventLevel logLevel = LevelAlias.Minimum,
             int? batchSizeLimit = null,
             TimeSpan? batchPeriod = null,
-            int? queueLimit = null)
+            int? queueLimit = null,
+            Action<Exception> exceptionHandler = null)
         {
             if (loggerConfiguration == null)
             {
@@ -57,7 +60,7 @@ namespace Serilog
             }
 
             configuration = (configuration != null) ? configuration : new DatadogConfiguration();
-            var sink = DatadogSink.Create(apiKey, source, service, host, tags, configuration, batchSizeLimit, batchPeriod, queueLimit);
+            var sink = DatadogSink.Create(apiKey, source, service, host, tags, configuration, batchSizeLimit, batchPeriod, queueLimit, exceptionHandler);
 
             return loggerConfiguration.Sink(sink, logLevel);
         }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/CannotSendLogEventException.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/CannotSendLogEventException.cs
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2020 Datadog, Inc.
+
+using System;
+using Serilog.Events;
+using System.Collections.Generic;
+
+namespace Serilog.Sinks.Datadog.Logs
+{
+    public class CannotSendLogEventException : Exception
+    {
+        public CannotSendLogEventException(string payload, IEnumerable<LogEvent> logEvents)
+            : base($"Could not send payload to Datadog: {payload}")
+        {
+            LogEvents = logEvents;
+        }
+
+        public IEnumerable<LogEvent> LogEvents { get; }
+    }
+}

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
@@ -100,7 +100,7 @@ namespace Serilog.Sinks.Datadog.Logs
             return new LogEventChunk
             {
                 Payload = prefix + String.Join(delimiter, collection) + suffix,
-                LogEvents = new List<LogEvent>(logEvents),
+                LogEvents = new List<LogEvent>(logEvents), // Copy `logEvents` as `logEvents` is reused.
             };
         }
 

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -26,24 +26,24 @@ namespace Serilog.Sinks.Datadog.Logs
         /// </summary>
         private const int DefaultBatchSizeLimit = 50;
 
-        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int? batchSizeLimit = null, TimeSpan? batchPeriod = null)
+        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, Action<Exception> exceptionHandler = null)
             : base(batchSizeLimit ?? DefaultBatchSizeLimit, batchPeriod ?? DefaultBatchPeriod)
         {
-            _client = CreateDatadogClient(apiKey, source, service, host, tags, config);
+            _client = CreateDatadogClient(apiKey, source, service, host, tags, config, exceptionHandler);
         }
 
-        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int queueLimit, int? batchSizeLimit = null, TimeSpan? batchPeriod = null)
+        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int queueLimit, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, Action<Exception> exceptionHandler = null)
             : base(batchSizeLimit ?? DefaultBatchSizeLimit, batchPeriod ?? DefaultBatchPeriod, queueLimit)
         {
-            _client = CreateDatadogClient(apiKey, source, service, host, tags, config);
+            _client = CreateDatadogClient(apiKey, source, service, host, tags, config, exceptionHandler);
         }
 
-        public static DatadogSink Create(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, int? queueLimit = null)
+        public static DatadogSink Create(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, int? queueLimit = null, Action<Exception> exceptionHandler = null)
         {
             if (queueLimit.HasValue)
-                return new DatadogSink(apiKey, source, service, host, tags, config, queueLimit.Value, batchSizeLimit, batchPeriod);
+                return new DatadogSink(apiKey, source, service, host, tags, config, queueLimit.Value, batchSizeLimit, batchPeriod, exceptionHandler);
 
-            return new DatadogSink(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod);
+            return new DatadogSink(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, exceptionHandler);
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace Serilog.Sinks.Datadog.Logs
             base.Dispose(disposing);
         }
 
-        private static IDatadogClient CreateDatadogClient(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration configuration)
+        private static IDatadogClient CreateDatadogClient(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration configuration, Action<Exception> exceptionHandler)
         {
             var logFormatter = new LogFormatter(source, service, host, tags);
             if (configuration.UseTCP)
@@ -80,7 +80,7 @@ namespace Serilog.Sinks.Datadog.Logs
             }
             else
             {
-                return new DatadogHttpClient(configuration, logFormatter, apiKey);
+                return new DatadogHttpClient(configuration, logFormatter, apiKey, exceptionHandler);
             }
         }
     }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/Exceptions/CannotSendLogEventException.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/Exceptions/CannotSendLogEventException.cs
@@ -3,20 +3,16 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2020 Datadog, Inc.
 
-using System;
 using Serilog.Events;
 using System.Collections.Generic;
 
 namespace Serilog.Sinks.Datadog.Logs
 {
-    public class CannotSendLogEventException : Exception
+    public class CannotSendLogEventException : LogEventException
     {
         public CannotSendLogEventException(string payload, IEnumerable<LogEvent> logEvents)
-            : base($"Could not send payload to Datadog: {payload}")
+            : base($"Could not send payload to Datadog: {payload}", logEvents)
         {
-            LogEvents = logEvents;
         }
-
-        public IEnumerable<LogEvent> LogEvents { get; }
     }
 }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/Exceptions/LogEventException.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/Exceptions/LogEventException.cs
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2020 Datadog, Inc.
+
+using System;
+using Serilog.Events;
+using System.Collections.Generic;
+
+namespace Serilog.Sinks.Datadog.Logs
+{
+    public class LogEventException : Exception
+    {
+        public LogEventException(string message, IEnumerable<LogEvent> logEvents)
+            : base(message)
+        {
+            LogEvents = logEvents;
+        }
+
+        public IEnumerable<LogEvent> LogEvents { get; }
+    }
+}

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/Exceptions/TooBigLogEventException.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/Exceptions/TooBigLogEventException.cs
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2020 Datadog, Inc.
+
+using Serilog.Events;
+using System.Collections.Generic;
+
+namespace Serilog.Sinks.Datadog.Logs
+{
+    public class TooBigLogEventException : LogEventException
+    {
+        public TooBigLogEventException(IEnumerable<LogEvent> logEvents)
+            : base($"The LogEvent instances are too big to be sent.", logEvents)
+        {
+        }
+    }
+}


### PR DESCRIPTION
Add an error handler when an exception occurs.

```C#
static void Main(string[] args)
{
    Log.Logger = new LoggerConfiguration()
        .WriteTo.DatadogLogs(API_KEY, exceptionHandler: e =>
        {
            var cannotSendLogEventException = e as CannotSendLogEventException;
            if (cannotSendLogEventException != null)
            {
                Console.WriteLine($"ERROR: {cannotSendLogEventException}  LogEvents Count: {cannotSendLogEventException.LogEvents.Count()}");
            }
        })
        .CreateLogger();

    Log.Information("Test serilog");
    Log.CloseAndFlush();
}
```