### PR TITLE
Add more .NET Framework targets to solve incompatibility issues with NuGet vs compiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.4
+
+* Add more net framework targets to solve incompatibility issues with NuGet version resolving to "nearest" .net framework vs compiler targets
+
 ## 0.3.3
 
 * Add a handler called when an exception occurs (#51).

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Serilog sink that send events and logs staight away to Datadog. By default the sink sends logs over HTTPS
 
 **Package** - [Serilog.Sinks.Datadog.Logs](http://nuget.org/packages/serilog.sinks.datadog.logs)
-| **Platforms** - .NET 4.5.1, .NET 4.7.2, netstandard1.3, netstandard2.0
+| **Platforms** - .NET 4.5, .NET 4.6, .NET 4.7.2, netstandard1.3, netstandard2.0
 
 Note: For other .NET versions, ensure that the default TLS version used is `1.2`
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Serilog sink that send events and logs staight away to Datadog. By default the sink sends logs over HTTPS
 
 **Package** - [Serilog.Sinks.Datadog.Logs](http://nuget.org/packages/serilog.sinks.datadog.logs)
-| **Platforms** - .NET 4.5.1, netstandard1.3, netstandard2.0
+| **Platforms** - .NET 4.5.1, .NET 4.7.2, netstandard1.3, netstandard2.0
 
 Note: For other .NET versions, ensure that the default TLS version used is `1.2`
 

--- a/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
+++ b/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.3;net45;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.3;net45;net46;net472</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.Datadog.Logs</AssemblyName>
     <PackageId>Serilog.Sinks.Datadog.Logs</PackageId>
     <PackageVersion>0.3.4</PackageVersion>
@@ -32,7 +32,7 @@
     <Compile Include="Configuration\Implementations\Microsoft.Extensions.Configuration\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net45'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 

--- a/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
+++ b/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.3;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.3;net45;net472</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.Datadog.Logs</AssemblyName>
     <PackageId>Serilog.Sinks.Datadog.Logs</PackageId>
-    <PackageVersion>0.3.3</PackageVersion>
+    <PackageVersion>0.3.4</PackageVersion>
     <Authors>Datadog</Authors>
     <Title>Serilog Sink Datadog Logs</Title>
     <Description>Serilog Sink that sends log events to Datadog https://www.datadoghq.com/</Description>
@@ -26,13 +26,17 @@
     <Compile Remove="Configuration\Implementations\Microsoft.Extensions.Configuration\**\*.*" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
     <Compile Include="Configuration\Extensions\Microsoft.Extensions.Configuration\**\*.cs" />
     <Compile Include="Configuration\Implementations\Microsoft.Extensions.Configuration\**\*.cs" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net472'">
+    <Reference Include="System.Net.Http" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0' And '$(TargetFramework)' != 'net472'">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <Compile Include="Configuration\Extensions\System.Configuration\**\*.cs" />
   </ItemGroup>


### PR DESCRIPTION
Fixes #39 by introducing .NET Framework 4.6/4.7.2 targets to allow the use of the correct System.Net.Http reference/package and Microsoft.Extensions.Configuration namespace/package and merge the "path" of all .netstandard2.0 supporting Framework versions.