### PR TITLE
Fix missing method exceptionfor461

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 A Serilog sink that send events and logs staight away to Datadog. By default the sink sends logs over HTTPS
 
 **Package** - [Serilog.Sinks.Datadog.Logs](http://nuget.org/packages/serilog.sinks.datadog.logs)
-| **Platforms** - .NET 4.5, .NET 4.6, .NET 4.7.2, netstandard1.3, netstandard2.0
+| **Platforms** - .NET 4.5, .NET 4.6.1, .NET 4.7.2, netstandard1.3, netstandard2.0
 
 Note: For other .NET versions, ensure that the default TLS version used is `1.2`
 

--- a/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
+++ b/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.3;net45;net46;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.3;net45;net461;net472</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.Datadog.Logs</AssemblyName>
     <PackageId>Serilog.Sinks.Datadog.Logs</PackageId>
     <PackageVersion>0.3.4</PackageVersion>
@@ -26,7 +26,7 @@
     <Compile Remove="Configuration\Implementations\Microsoft.Extensions.Configuration\**\*.*" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net461'">
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
     <Compile Include="Configuration\Extensions\Microsoft.Extensions.Configuration\**\*.cs" />
     <Compile Include="Configuration\Implementations\Microsoft.Extensions.Configuration\**\*.cs" />
@@ -36,7 +36,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0' And '$(TargetFramework)' != 'net472'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0' And '$(TargetFramework)' != 'net472' And '$(TargetFramework)' != 'net461'">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <Compile Include="Configuration\Extensions\System.Configuration\**\*.cs" />
   </ItemGroup>


### PR DESCRIPTION
Fix MissingMethodException when using .NET 4.61 with .NET Standard 2.0