### PR TITLE
Add parameter specyfing whether to map Serilog key words to Datadog reserved attributes

### DIFF
--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -34,7 +34,7 @@ namespace Serilog
         /// Maximum number of events to hold in the sink's internal queue, or <c>null</c>
         /// for an unbounded queue. The default is <c>10000</c>
         /// </param>
-        /// <param name="exceptionHandler">This function is called when an exception occurs when using 
+        /// <param name="exceptionHandler">This function is called when an exception occurs when using
         /// DatadogConfiguration.UseTCP=false (the default configuration)</param>
         /// <returns>Logger configuration</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
@@ -51,7 +51,8 @@ namespace Serilog
             int? batchSizeLimit = null,
             TimeSpan? batchPeriod = null,
             int? queueLimit = null,
-            Action<Exception> exceptionHandler = null)
+            Action<Exception> exceptionHandler = null,
+            bool renameProperties = false)
         {
             if (loggerConfiguration == null)
             {
@@ -63,7 +64,7 @@ namespace Serilog
             }
 
             var config = ApplyMicrosoftExtensionsConfiguration.ConfigureDatadogConfiguration(configuration, configurationSection);
-            var sink = DatadogSink.Create(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, queueLimit, exceptionHandler);
+            var sink = DatadogSink.Create(apiKey, source, service, host, tags, renameProperties, config, batchSizeLimit, batchPeriod, queueLimit, exceptionHandler);
 
             return loggerConfiguration.Sink(sink, logLevel);
         }

--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/System.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/System.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -32,8 +32,9 @@ namespace Serilog
         /// Maximum number of events to hold in the sink's internal queue, or <c>null</c>
         /// for an unbounded queue. The default is <c>10000</c>
         /// </param>
-        /// <param name="exceptionHandler">This function is called when an exception occurs when using 
+        /// <param name="exceptionHandler">This function is called when an exception occurs when using
         /// DatadogConfiguration.UseTCP=false (the default configuration)</param>
+        /// <param name="renameProperties">Specifies whether to map Serilog key words to Datadog reserved attributes</param>
         /// <returns>Logger configuration</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration DatadogLogs(
@@ -48,7 +49,8 @@ namespace Serilog
             int? batchSizeLimit = null,
             TimeSpan? batchPeriod = null,
             int? queueLimit = null,
-            Action<Exception> exceptionHandler = null)
+            Action<Exception> exceptionHandler = null,
+            bool renameProperties = false)
         {
             if (loggerConfiguration == null)
             {
@@ -60,7 +62,7 @@ namespace Serilog
             }
 
             configuration = (configuration != null) ? configuration : new DatadogConfiguration();
-            var sink = DatadogSink.Create(apiKey, source, service, host, tags, configuration, batchSizeLimit, batchPeriod, queueLimit, exceptionHandler);
+            var sink = DatadogSink.Create(apiKey, source, service, host, tags, renameProperties, configuration, batchSizeLimit, batchPeriod, queueLimit, exceptionHandler);
 
             return loggerConfiguration.Sink(sink, logLevel);
         }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -28,26 +28,34 @@ namespace Serilog.Sinks.Datadog.Logs
         /// </summary>
         private const int DefaultBatchSizeLimit = 50;
 
-        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, Action<Exception> exceptionHandler = null)
+        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, bool renameProperties,
+            DatadogConfiguration config, int? batchSizeLimit = null, TimeSpan? batchPeriod = null,
+            Action<Exception> exceptionHandler = null)
             : base(batchSizeLimit ?? DefaultBatchSizeLimit, batchPeriod ?? DefaultBatchPeriod)
         {
-            _client = CreateDatadogClient(apiKey, source, service, host, tags, config);
+            _client = CreateDatadogClient(apiKey, source, service, host, tags, renameProperties, config);
             _exceptionHandler = exceptionHandler;
         }
 
-        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int queueLimit, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, Action<Exception> exceptionHandler = null)
+        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, bool renameProperties,
+            DatadogConfiguration config, int queueLimit, int? batchSizeLimit = null, TimeSpan? batchPeriod = null,
+            Action<Exception> exceptionHandler = null)
             : base(batchSizeLimit ?? DefaultBatchSizeLimit, batchPeriod ?? DefaultBatchPeriod, queueLimit)
         {
-            _client = CreateDatadogClient(apiKey, source, service, host, tags, config);
+            _client = CreateDatadogClient(apiKey, source, service, host, tags, renameProperties ,config);
             _exceptionHandler = exceptionHandler;
         }
 
-        public static DatadogSink Create(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, int? queueLimit = null, Action<Exception> exceptionHandler = null)
+        public static DatadogSink Create(string apiKey, string source, string service, string host, string[] tags,
+            bool renameProperties, DatadogConfiguration config, int? batchSizeLimit = null,
+            TimeSpan? batchPeriod = null, int? queueLimit = null, Action<Exception> exceptionHandler = null)
         {
             if (queueLimit.HasValue)
-                return new DatadogSink(apiKey, source, service, host, tags, config, queueLimit.Value, batchSizeLimit, batchPeriod, exceptionHandler);
+                return new DatadogSink(apiKey, source, service, host, tags, renameProperties, config, queueLimit.Value, batchSizeLimit,
+                    batchPeriod, exceptionHandler);
 
-            return new DatadogSink(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, exceptionHandler);
+            return new DatadogSink(apiKey, source, service, host, tags, renameProperties, config, batchSizeLimit, batchPeriod,
+                exceptionHandler);
         }
 
         /// <summary>
@@ -83,9 +91,10 @@ namespace Serilog.Sinks.Datadog.Logs
             base.Dispose(disposing);
         }
 
-        private static IDatadogClient CreateDatadogClient(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration configuration)
+        private static IDatadogClient CreateDatadogClient(string apiKey, string source, string service, string host,
+            string[] tags, bool renameProperties, DatadogConfiguration configuration)
         {
-            var logFormatter = new LogFormatter(source, service, host, tags);
+            var logFormatter = new LogFormatter(source, service, host, tags, renameProperties);
             if (configuration.UseTCP)
             {
                 return new DatadogTcpClient(configuration, logFormatter, apiKey);

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
@@ -17,6 +17,7 @@ namespace Serilog.Sinks.Datadog.Logs
         private readonly string _service;
         private readonly string _host;
         private readonly string _tags;
+        private readonly bool _renameProperties;
 
         /// <summary>
         /// Default source value for the serilog integration.
@@ -33,11 +34,12 @@ namespace Serilog.Sinks.Datadog.Logs
         /// </summary>
         private static readonly JsonSerializerSettings settings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
 
-        public LogFormatter(string source, string service, string host, string[] tags)
+        public LogFormatter(string source, string service, string host, string[] tags, bool renameProperties)
         {
             _source = source ?? CSHARP;
             _service = service;
             _host = host;
+            _renameProperties = renameProperties;
             _tags = tags != null ? string.Join(",", tags) : null;
         }
 
@@ -60,7 +62,7 @@ namespace Serilog.Sinks.Datadog.Logs
             if (_host != null) { logEventAsDict.Add("host", _host); }
             if (_tags != null) { logEventAsDict.Add("ddtags", _tags); }
 
-            if (_source != CSHARP) RenameAttributesToDatadogReservedAttributes(logEventAsDict);
+            if (_renameProperties) RenameAttributesToDatadogReservedAttributes(logEventAsDict);
 
             // Convert back the dict to a JSON string
             return JsonConvert.SerializeObject(logEventAsDict, Newtonsoft.Json.Formatting.None, settings);

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
@@ -60,13 +60,20 @@ namespace Serilog.Sinks.Datadog.Logs
             if (_host != null) { logEventAsDict.Add("host", _host); }
             if (_tags != null) { logEventAsDict.Add("ddtags", _tags); }
 
-            // Rename serilog attributes to Datadog reserved attributes to have them properly
-            // displayed on the Log Explorer
-            RenameKey(logEventAsDict, "RenderedMessage", "message");
-            RenameKey(logEventAsDict, "Level", "level");
+            if (_source != CSHARP) RenameAttributesToDatadogReservedAttributes(logEventAsDict);
 
             // Convert back the dict to a JSON string
             return JsonConvert.SerializeObject(logEventAsDict, Newtonsoft.Json.Formatting.None, settings);
+        }
+
+        /// <summary>
+        /// Rename serilog attributes to Datadog reserved attributes to have them properly
+        /// displayed on the Log Explorer
+        /// </summary>
+        private void RenameAttributesToDatadogReservedAttributes(Dictionary<string, dynamic> logEventAsDict)
+        {
+            RenameKey(logEventAsDict, "RenderedMessage", "message");
+            RenameKey(logEventAsDict, "Level", "level");
         }
 
         /// <summary>


### PR DESCRIPTION
Fix #56 

Add attribute so that the user can specify whether to rename Serilogs attributes `RenderedMessage` to `message` and `Level` to `level`.

When using the current default pipeline for `csharp` source, those attributes should not be mapped.