### PR TITLE
Feature/config retries

### DIFF
--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Implementations/Microsoft.Extensions.Configuration/ApplyMicrosoftExtensionsConfiguration.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Implementations/Microsoft.Extensions.Configuration/ApplyMicrosoftExtensionsConfiguration.cs
@@ -17,13 +17,13 @@ namespace Serilog.Sinks.Datadog.Logs
         /// Create the DatadogConfiguration object or apply any configuration changes to it.
         /// </summary>
         /// <param name="datadogConfiguration">An optional externally-created DatadogConfiguration object to be updated with additional configuration values.</param>
-        /// <param name="config">A configuration section typically named "configurationSection".</param>
+        /// <param name="configurationSection">A configuration section typically named "configurationSection".</param>
         /// <returns>The "merged" DatadogConfiguration object.</returns>
-        internal static DatadogConfiguration ConfigureDatadogConfiguration(DatadogConfiguration datadogConfiguration, IConfigurationSection configurationOption)
+        internal static DatadogConfiguration ConfigureDatadogConfiguration(DatadogConfiguration datadogConfiguration, IConfigurationSection configurationSection)
         {
-            if (configurationOption == null || !configurationOption.GetChildren().Any()) return datadogConfiguration ?? new DatadogConfiguration();
+            if (configurationSection == null || !configurationSection.GetChildren().Any()) return datadogConfiguration ?? new DatadogConfiguration();
 
-            var section = configurationOption.Get<DatadogConfiguration>();
+            var section = configurationSection.Get<DatadogConfiguration>();
 
             return new DatadogConfiguration(
                 url: datadogConfiguration?.Url ?? section.Url,

--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Implementations/Microsoft.Extensions.Configuration/ApplyMicrosoftExtensionsConfiguration.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Implementations/Microsoft.Extensions.Configuration/ApplyMicrosoftExtensionsConfiguration.cs
@@ -29,7 +29,8 @@ namespace Serilog.Sinks.Datadog.Logs
                 url: datadogConfiguration?.Url ?? section.Url,
                 port: datadogConfiguration?.Port ?? section.Port,
                 useSSL: datadogConfiguration?.UseSSL ?? section.UseSSL,
-                useTCP: datadogConfiguration?.UseTCP ?? section.UseTCP
+                useTCP: datadogConfiguration?.UseTCP ?? section.UseTCP,
+                maxRetries:datadogConfiguration?.MaxRetries ?? section.MaxRetries
             );
         }
     }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogConfiguration.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogConfiguration.cs
@@ -45,20 +45,23 @@ namespace Serilog.Sinks.Datadog.Logs
         /// </summary>
         public bool UseTCP { get; set; }
 
+        /// <summary>
+        /// Number of retries before the client gives up logging.
+        /// </summary>
+        public int MaxRetries { get; set; }
+
         public DatadogConfiguration() : this(DDUrl, DDPort, true, false) {
         }
 
-        public DatadogConfiguration(string url = DDUrl, int port = DDPort, bool useSSL = true, bool useTCP = false)
+        public DatadogConfiguration(string url = DDUrl, int port = DDPort, bool useSSL = true, bool useTCP = false, int maxRetries = 10)
         {
             Url = url;
             Port = port;
             UseSSL = useSSL;
             UseTCP = useTCP;
+            MaxRetries = maxRetries;
         }
 
-        public override string ToString()
-        {
-            return string.Format("{{ Url: {0}, Port: {1}, UseSSL: {2}, UseTCP: {3} }}", Url, Port, UseSSL, UseTCP);
-        }
+        public override string ToString() => $"{{ Url: {Url}, Port: {Port}, UseSSL: {UseSSL}, UseTCP: {UseTCP} }}";
     }
 }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
@@ -25,11 +25,6 @@ namespace Serilog.Sinks.Datadog.Logs
         private readonly HttpClient _client;
 
         /// <summary>
-        /// Max number of retries when sending failed.
-        /// </summary>
-        private const int MaxRetries = 10;
-
-        /// <summary>
         /// Max backoff used when sending failed.
         /// </summary>
         private const int MaxBackoff = 30;
@@ -115,7 +110,7 @@ namespace Serilog.Sinks.Datadog.Logs
         {
             var payload = logEventChunk.Payload;
             var content = new StringContent(payload, Encoding.UTF8, _content);
-            for (int retry = 0; retry < MaxRetries; retry++)
+            for (int retry = 0; retry < _config.MaxRetries; retry++)
             {
                 int backoff = (int)Math.Min(Math.Pow(2, retry), MaxBackoff);
                 if (retry > 0)

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
@@ -69,7 +69,7 @@ namespace Serilog.Sinks.Datadog.Logs
             var logEvents = new List<LogEvent>(events.Count);
             foreach (var logEvent in events)
             {
-                var formattedLog = _formatter.formatMessage(logEvent);
+                var formattedLog = _formatter.FormatMessage(logEvent);
                 var logSize = Encoding.UTF8.GetByteCount(formattedLog);
                 if (logSize > _maxMessageSize)
                 {

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
@@ -128,7 +128,6 @@ namespace Serilog.Sinks.Datadog.Logs
                 }
                 catch (Exception)
                 {
-                    continue;
                 }
             }
 

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
@@ -42,7 +42,7 @@ namespace Serilog.Sinks.Datadog.Logs
             _formatter = formatter;
         }
 
-        public Task WriteAsync(IEnumerable<LogEvent> events)
+        public Task WriteAsync(IReadOnlyCollection<LogEvent> events)
         {
             var serializedEvents = SerializeEvents(events);
             var tasks = serializedEvents.LogEventChunks.Select(Post);
@@ -60,13 +60,13 @@ namespace Serilog.Sinks.Datadog.Logs
             return Task.WhenAll(tasks);
         }
 
-        private SerializedEvents SerializeEvents(IEnumerable<LogEvent> events)
+        private SerializedEvents SerializeEvents(IReadOnlyCollection<LogEvent> events)
         {
             var serializedEvents = new SerializedEvents();
             int currentSize = 0;
 
-            var chunkBuffer = new List<string>(events.Count());
-            var logEvents = new List<LogEvent>(events.Count());
+            var chunkBuffer = new List<string>(events.Count);
+            var logEvents = new List<LogEvent>(events.Count);
             foreach (var logEvent in events)
             {
                 var formattedLog = _formatter.formatMessage(logEvent);

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -58,12 +58,13 @@ namespace Serilog.Sinks.Datadog.Logs
         {
             try
             {
-                if (!events.Any())
+                var batch = events.ToArray();
+                if (!batch.Any())
                 {
                     return;
                 }
 
-                var task = _client.WriteAsync(events);
+                var task = _client.WriteAsync(batch);
                 await RunTask(task);
             }
             catch (Exception e)

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -91,10 +91,8 @@ namespace Serilog.Sinks.Datadog.Logs
             {
                 return new DatadogTcpClient(configuration, logFormatter, apiKey);
             }
-            else
-            {
-                return new DatadogHttpClient(configuration, logFormatter, apiKey);
-            }
+
+            return new DatadogHttpClient(configuration, logFormatter, apiKey);
         }
 
         private async Task RunTask(Task task)

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogTcpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogTcpClient.cs
@@ -73,7 +73,7 @@ namespace Serilog.Sinks.Datadog.Logs
             }
         }
 
-        public async Task WriteAsync(IEnumerable<LogEvent> events)
+        public async Task WriteAsync(IReadOnlyCollection<LogEvent> events)
         {
             var payloadBuilder = new StringBuilder();
             foreach (var logEvent in events)

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogTcpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogTcpClient.cs
@@ -37,11 +37,6 @@ namespace Serilog.Sinks.Datadog.Logs
         private const string MessageDelimiter = "\n";
 
         /// <summary>
-        /// Max number of retries when sending failed.
-        /// </summary>
-        private const int MaxRetries = 5;
-
-        /// <summary>
         /// Max backoff used when sending failed.
         /// </summary>
         private const int MaxBackoff = 30;
@@ -89,7 +84,7 @@ namespace Serilog.Sinks.Datadog.Logs
             }
             string payload = payloadBuilder.ToString();
 
-            for (int retry = 0; retry < MaxRetries; retry++)
+            for (int retry = 0; retry < _config.MaxRetries; retry++)
             {
                 int backoff = (int)Math.Min(Math.Pow(retry, 2), MaxBackoff);
                 if (retry > 0)

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogTcpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogTcpClient.cs
@@ -79,7 +79,7 @@ namespace Serilog.Sinks.Datadog.Logs
             foreach (var logEvent in events)
             {
                 payloadBuilder.Append(_apiKey + WhiteSpace);
-                payloadBuilder.Append(_formatter.formatMessage(logEvent));
+                payloadBuilder.Append(_formatter.FormatMessage(logEvent));
                 payloadBuilder.Append(MessageDelimiter);
             }
             string payload = payloadBuilder.ToString();

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/Exceptions/TooBigLogEventException.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/Exceptions/TooBigLogEventException.cs
@@ -11,7 +11,7 @@ namespace Serilog.Sinks.Datadog.Logs
     public class TooBigLogEventException : LogEventException
     {
         public TooBigLogEventException(IEnumerable<LogEvent> logEvents)
-            : base($"The LogEvent instances are too big to be sent.", logEvents)
+            : base("The LogEvent instances are too big to be sent.", logEvents)
         {
         }
     }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/IDatadogClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/IDatadogClient.cs
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019 Datadog, Inc.
 
-using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Serilog.Events;

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/IDatadogClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/IDatadogClient.cs
@@ -16,7 +16,7 @@ namespace Serilog.Sinks.Datadog.Logs
         /// Send payload to Datadog logs-backend.
         /// </summary>
         /// <param name="events">Serilog events to send.</param>
-        Task WriteAsync(IEnumerable<LogEvent> events);
+        Task WriteAsync(IReadOnlyCollection<LogEvent> events);
 
         /// <summary>
         /// Cleanup existing resources.

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
@@ -54,7 +54,7 @@ namespace Serilog.Sinks.Datadog.Logs
             // internal structure of the logEvent to give a nicely formatted JSON
             formatter.Format(logEvent, writer);
 
-            // Convert the JSON to a dictionnary and add the DataDog properties
+            // Convert the JSON to a dictionary and add the DataDog properties
             var logEventAsDict = JsonConvert.DeserializeObject<Dictionary<string, dynamic>>(payload.ToString());
             if (_source != null) { logEventAsDict.Add("ddsource", _source); }
             if (_service != null) { logEventAsDict.Add("service",_service); }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using Serilog.Events;
 using Serilog.Formatting.Json;
 using Newtonsoft.Json;
+
 namespace Serilog.Sinks.Datadog.Logs
 {
     public class LogFormatter

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
@@ -45,7 +45,7 @@ namespace Serilog.Sinks.Datadog.Logs
         /// <summary>
         /// formatMessage enrich the log event with DataDog metadata such as source, service, host and tags.
         /// </summary>
-        public string formatMessage(LogEvent logEvent)
+        public string FormatMessage(LogEvent logEvent)
         {
             var payload = new StringBuilder();
             var writer = new StringWriter(payload);


### PR DESCRIPTION
Makes the number of retries configurable before the `IDataDogClient` gives up logging by adding a new `DataDogConfiguration.MaxRetries` property.

Default value: `10`.