### PR TITLE
Handle TCP disconnection.

### DIFF
--- a/Serilog.Sinks.Datadog.Logs.sln
+++ b/Serilog.Sinks.Datadog.Logs.sln
@@ -1,4 +1,4 @@
-
+﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
 VisualStudioVersion = 15.0.26124.0
@@ -6,6 +6,10 @@ MinimumVisualStudioVersion = 15.0.26124.0
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{D0A5A0BA-56F9-4C56-8785-8C9F23A3B411}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Datadog.Logs", "src\Serilog.Sinks.Datadog.Logs\Serilog.Sinks.Datadog.Logs.csproj", "{897105F7-58A7-4849-98A8-EB8EDD450E47}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{CDDB8CB1-42E1-4722-8D83-4BB298ED5D16}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Serilog.Sinks.Datadog.Logs.Tests", "tests\Serilog.Sinks.Datadog.Logs.Tests\Serilog.Sinks.Datadog.Logs.Tests.csproj", "{54D06DEA-0F0B-4D2A-ADDA-2F5221EE036C}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -32,8 +36,21 @@ Global
 		{897105F7-58A7-4849-98A8-EB8EDD450E47}.Release|x64.Build.0 = Release|x64
 		{897105F7-58A7-4849-98A8-EB8EDD450E47}.Release|x86.ActiveCfg = Release|x86
 		{897105F7-58A7-4849-98A8-EB8EDD450E47}.Release|x86.Build.0 = Release|x86
+		{54D06DEA-0F0B-4D2A-ADDA-2F5221EE036C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{54D06DEA-0F0B-4D2A-ADDA-2F5221EE036C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{54D06DEA-0F0B-4D2A-ADDA-2F5221EE036C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{54D06DEA-0F0B-4D2A-ADDA-2F5221EE036C}.Debug|x64.Build.0 = Debug|Any CPU
+		{54D06DEA-0F0B-4D2A-ADDA-2F5221EE036C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{54D06DEA-0F0B-4D2A-ADDA-2F5221EE036C}.Debug|x86.Build.0 = Debug|Any CPU
+		{54D06DEA-0F0B-4D2A-ADDA-2F5221EE036C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{54D06DEA-0F0B-4D2A-ADDA-2F5221EE036C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{54D06DEA-0F0B-4D2A-ADDA-2F5221EE036C}.Release|x64.ActiveCfg = Release|Any CPU
+		{54D06DEA-0F0B-4D2A-ADDA-2F5221EE036C}.Release|x64.Build.0 = Release|Any CPU
+		{54D06DEA-0F0B-4D2A-ADDA-2F5221EE036C}.Release|x86.ActiveCfg = Release|Any CPU
+		{54D06DEA-0F0B-4D2A-ADDA-2F5221EE036C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{897105F7-58A7-4849-98A8-EB8EDD450E47} = {D0A5A0BA-56F9-4C56-8785-8C9F23A3B411}
+		{54D06DEA-0F0B-4D2A-ADDA-2F5221EE036C} = {CDDB8CB1-42E1-4722-8D83-4BB298ED5D16}
 	EndGlobalSection
 EndGlobal

--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -51,7 +51,8 @@ namespace Serilog
             int? batchSizeLimit = null,
             TimeSpan? batchPeriod = null,
             int? queueLimit = null,
-            Action<Exception> exceptionHandler = null)
+            Action<Exception> exceptionHandler = null,
+            bool detectTCPDisconnection = false)
         {
             if (loggerConfiguration == null)
             {
@@ -63,7 +64,7 @@ namespace Serilog
             }
 
             var config = ApplyMicrosoftExtensionsConfiguration.ConfigureDatadogConfiguration(configuration, configurationSection);
-            var sink = DatadogSink.Create(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, queueLimit, exceptionHandler);
+            var sink = DatadogSink.Create(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, queueLimit, exceptionHandler, detectTCPDisconnection);
 
             return loggerConfiguration.Sink(sink, logLevel);
         }

--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -36,6 +36,7 @@ namespace Serilog
         /// </param>
         /// <param name="exceptionHandler">This function is called when an exception occurs when using 
         /// DatadogConfiguration.UseTCP=false (the default configuration)</param>
+        /// <param name="detectTCPDisconnection">Detect when the TCP connection is lost and recreate a new connection.</param>
         /// <returns>Logger configuration</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration DatadogLogs(

--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/System.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/System.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -48,7 +48,8 @@ namespace Serilog
             int? batchSizeLimit = null,
             TimeSpan? batchPeriod = null,
             int? queueLimit = null,
-            Action<Exception> exceptionHandler = null)
+            Action<Exception> exceptionHandler = null,
+            bool detectTCPDisconnection = false)
         {
             if (loggerConfiguration == null)
             {
@@ -60,7 +61,7 @@ namespace Serilog
             }
 
             configuration = (configuration != null) ? configuration : new DatadogConfiguration();
-            var sink = DatadogSink.Create(apiKey, source, service, host, tags, configuration, batchSizeLimit, batchPeriod, queueLimit, exceptionHandler);
+            var sink = DatadogSink.Create(apiKey, source, service, host, tags, configuration, batchSizeLimit, batchPeriod, queueLimit, exceptionHandler, detectTCPDisconnection);
 
             return loggerConfiguration.Sink(sink, logLevel);
         }

--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/System.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/System.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -34,6 +34,7 @@ namespace Serilog
         /// </param>
         /// <param name="exceptionHandler">This function is called when an exception occurs when using 
         /// DatadogConfiguration.UseTCP=false (the default configuration)</param>
+        /// <param name="detectTCPDisconnection">Detect when the TCP connection is lost and recreate a new connection.</param>
         /// <returns>Logger configuration</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration DatadogLogs(

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/ConnectionMatcher.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/ConnectionMatcher.cs
@@ -1,0 +1,43 @@
+using System.Net;
+
+namespace Serilog.Sinks.Datadog.Logs
+{
+    internal class ConnectionMatcher
+    {
+        readonly private IPEndPoint _localIPv4;
+        readonly private IPEndPoint _localIPv6;
+        readonly private IPEndPoint _remoteIPv4;
+        readonly private IPEndPoint _remoteIPv6;
+
+        public static ConnectionMatcher TryCreate(EndPoint local, EndPoint remote)
+        {
+            if (local is IPEndPoint localIp && remote is IPEndPoint remoteIp)
+            {
+                return new ConnectionMatcher(
+                    new IPEndPoint(localIp.Address.MapToIPv4(), localIp.Port),
+                    new IPEndPoint(localIp.Address.MapToIPv6(), localIp.Port),
+                    new IPEndPoint(remoteIp.Address.MapToIPv4(), remoteIp.Port),
+                    new IPEndPoint(remoteIp.Address.MapToIPv6(), remoteIp.Port));
+            }
+            return null;
+        }
+
+        public bool IsSameConnection(EndPoint local, EndPoint remote)
+        {
+            return (_localIPv4.Equals(local) || _localIPv6.Equals(local))
+            && (_remoteIPv4.Equals(remote) || _remoteIPv6.Equals(remote));
+        }
+
+        private ConnectionMatcher(
+            IPEndPoint localIPv4,
+            IPEndPoint localIPv6,
+            IPEndPoint remoteIPv4,
+            IPEndPoint remoteIPv6)
+        {
+            _localIPv4 = localIPv4;
+            _localIPv6 = localIPv6;
+            _remoteIPv4 = remoteIPv4;
+            _remoteIPv6 = remoteIPv6;
+        }
+    }
+}

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -6,10 +6,13 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Sinks.PeriodicBatching;
+
+[assembly: InternalsVisibleTo("Serilog.Sinks.Datadog.Logs.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100a188c93acb61ca68b3b11e5047e3602ffea902e7413310ce96cdd8e31992d36d9276cd36ce55b7870a39379fec698b458bebaa0dc8c72b5e438c7418d640c9bc46a21af3f08a48b68aa8ec23fe0d01bcdcfa5126c66e7586ae08dc1c21142b2c7d49cb09649a2fc9ba767fc88fee6347536a51d28ff398eaabb760494db90dd0")]
 
 namespace Serilog.Sinks.Datadog.Logs
 {

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -31,26 +31,37 @@ namespace Serilog.Sinks.Datadog.Logs
         /// </summary>
         private const int DefaultBatchSizeLimit = 50;
 
-        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, Action<Exception> exceptionHandler = null)
+        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, Action<Exception> exceptionHandler = null, bool detectTCPDisconnection = false)
             : base(batchSizeLimit ?? DefaultBatchSizeLimit, batchPeriod ?? DefaultBatchPeriod)
         {
-            _client = CreateDatadogClient(apiKey, source, service, host, tags, config);
+            _client = CreateDatadogClient(apiKey, source, service, host, tags, config, detectTCPDisconnection);
             _exceptionHandler = exceptionHandler;
         }
 
-        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int queueLimit, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, Action<Exception> exceptionHandler = null)
+        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int queueLimit, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, Action<Exception> exceptionHandler = null, bool detectTCPDisconnection = false)
             : base(batchSizeLimit ?? DefaultBatchSizeLimit, batchPeriod ?? DefaultBatchPeriod, queueLimit)
         {
-            _client = CreateDatadogClient(apiKey, source, service, host, tags, config);
+            _client = CreateDatadogClient(apiKey, source, service, host, tags, config, detectTCPDisconnection);
             _exceptionHandler = exceptionHandler;
         }
 
-        public static DatadogSink Create(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, int? queueLimit = null, Action<Exception> exceptionHandler = null)
+        public static DatadogSink Create(
+            string apiKey, 
+            string source, 
+            string service, 
+            string host, 
+            string[] tags, 
+            DatadogConfiguration config, 
+            int? batchSizeLimit = null, 
+            TimeSpan? batchPeriod = null, 
+            int? queueLimit = null, 
+            Action<Exception> exceptionHandler = null, 
+            bool detectTCPDisconnection = false)
         {
             if (queueLimit.HasValue)
-                return new DatadogSink(apiKey, source, service, host, tags, config, queueLimit.Value, batchSizeLimit, batchPeriod, exceptionHandler);
+                return new DatadogSink(apiKey, source, service, host, tags, config, queueLimit.Value, batchSizeLimit, batchPeriod, exceptionHandler, detectTCPDisconnection);
 
-            return new DatadogSink(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, exceptionHandler);
+            return new DatadogSink(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, exceptionHandler, detectTCPDisconnection);
         }
 
         /// <summary>
@@ -86,12 +97,12 @@ namespace Serilog.Sinks.Datadog.Logs
             base.Dispose(disposing);
         }
 
-        private static IDatadogClient CreateDatadogClient(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration configuration)
+        private static IDatadogClient CreateDatadogClient(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration configuration, bool detectTCPDisconnection)
         {
             var logFormatter = new LogFormatter(source, service, host, tags);
             if (configuration.UseTCP)
             {
-                return new DatadogTcpClient(configuration, logFormatter, apiKey);
+                return new DatadogTcpClient(configuration, logFormatter, apiKey, detectTCPDisconnection);
             }
             else
             {

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogTcpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogTcpClient.cs
@@ -200,45 +200,6 @@ namespace Serilog.Sinks.Datadog.Logs
                 }
                 CloseConnection();
             }
-        }
-
-        private class ConnectionMatcher
-        {
-            readonly private IPEndPoint _localIPv4;
-            readonly private IPEndPoint _localIPv6;
-            readonly private IPEndPoint _remoteIPv4;
-            readonly private IPEndPoint _remoteIPv6;
-
-            public static ConnectionMatcher TryCreate(EndPoint local, EndPoint remote)
-            {
-                if (local is IPEndPoint localIp && remote is IPEndPoint remoteIp)
-                {
-                    return new ConnectionMatcher(
-                        new IPEndPoint(localIp.Address.MapToIPv4(), localIp.Port),
-                        new IPEndPoint(localIp.Address.MapToIPv6(), localIp.Port),
-                        new IPEndPoint(remoteIp.Address.MapToIPv4(), remoteIp.Port),
-                        new IPEndPoint(remoteIp.Address.MapToIPv6(), remoteIp.Port));
-                }
-                return null;
-            }
-
-            public bool IsSameConnection(EndPoint local, EndPoint remote)
-            {
-                return (_localIPv4.Equals(local) || _localIPv6.Equals(local))
-                && (_remoteIPv4.Equals(remote) || _remoteIPv6.Equals(remote));
-            }
-
-            private ConnectionMatcher(
-                IPEndPoint localIPv4,
-                IPEndPoint localIPv6,
-                IPEndPoint remoteIPv4,
-                IPEndPoint remoteIPv6)
-            {
-                _localIPv4 = localIPv4;
-                _localIPv6 = localIPv6;
-                _remoteIPv4 = remoteIPv4;
-                _remoteIPv6 = remoteIPv6;
-            }
-        }
+        }        
     }
 }

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/ConnectionMatcherTests.cs
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/ConnectionMatcherTests.cs
@@ -1,0 +1,31 @@
+﻿using System.Net;
+using NUnit.Framework;
+
+namespace Serilog.Sinks.Datadog.Logs.Tests
+{
+    [TestFixture]
+    public class ConnectionMatcherTests
+    {
+        IPAddress localIPAddress = IPAddress.Parse("127.0.0.1");
+        IPAddress remoteIPAddress = IPAddress.Parse("127.0.0.2");
+
+        [Test]
+        public void IsSameConnection()
+        {
+            EndPoint localEndPoint = new IPEndPoint(localIPAddress, 10);
+            EndPoint remoteEndPoint = new IPEndPoint(remoteIPAddress, 20);
+
+            var connectionMatcher = ConnectionMatcher.TryCreate(localEndPoint, remoteEndPoint);
+            Assert.That(connectionMatcher.IsSameConnection(
+                new IPEndPoint(localIPAddress.MapToIPv4(), 10),
+                new IPEndPoint(remoteIPAddress.MapToIPv4(), 20)), Is.True);
+            Assert.That(connectionMatcher.IsSameConnection(
+                new IPEndPoint(localIPAddress.MapToIPv6(), 10),
+                new IPEndPoint(remoteIPAddress.MapToIPv6(), 20)), Is.True);
+            Assert.That(connectionMatcher.IsSameConnection(
+                new IPEndPoint(remoteIPAddress.MapToIPv6(), 10),
+                new IPEndPoint(remoteIPAddress.MapToIPv6(), 20)), Is.False);
+        }
+    }
+}
+

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/Serilog.Sinks.Datadog.Logs.Tests.csproj
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/Serilog.Sinks.Datadog.Logs.Tests.csproj
@@ -1,0 +1,15 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <SignAssembly>true</SignAssembly>
+    <AssemblyOriginatorKeyFile>..\..\Serilog.Sinks.Datadog.Logs.snk</AssemblyOriginatorKeyFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NUnit" Version="3.13.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
+    <ProjectReference Include="../../src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
This PR handles TCP disconnection issues which lead to missing logs. See https://github.com/DataDog/serilog-sinks-datadog-logs/issues/21 for more details.
This PR is based from https://github.com/DataDog/serilog-sinks-datadog-logs/pull/20.

As an alternative solution, when the service disconnect, `TcpClient.Available` is greater than `0` when the service disconnect (at least in some cases). I did not implement this solution as I do not want to make assumption about what the server sends.
As `netstandard1.3` is deprecated  and mono on MacOS are not so common, it is better to use `GetActiveTcpConnections` to check if the tcp connection is established. 

Note: 
 - On Windows `GetActiveTcpConnections` return IPv4 adresses whereas `TcpClient.LocalEndPoint` and `TcpClient.RemoteEndPoint` return IPv6 adresses. 
 - The fix is not implemented for  `netstandard1.3` and for mono on MacOS.
 - There is a tiny time window between the call to `IsConnectionClosed()` and `_stream.Write(data, 0, data.Length);` where a disconnection to the TCP connection is not detected. As `_stream.Write(data, 0, data.Length);` does not throw when the TCP connection is not established, there is no way to detect this case.