### PR TITLE
Remove unused UTF8 property

### DIFF
--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
@@ -34,11 +34,6 @@ namespace Serilog.Sinks.Datadog.Logs
         /// </summary>
         private const int MaxBackoff = 30;
 
-        /// <summary>
-        /// Shared UTF8 encoder.
-        /// </summary>
-        private static readonly UTF8Encoding UTF8 = new UTF8Encoding();
-
         public DatadogHttpClient(DatadogConfiguration config, LogFormatter formatter, string apiKey)
         {
             _config = config;


### PR DESCRIPTION
Like in [#41](
https://github.com/DataDog/serilog-sinks-datadog-logs/pull/41/files#diff-391fbc7d1e0f1155c7b0c7bbc40cc3edc38918a8c7d3ac93646de32f3adef703L34) and [#42](https://github.com/DataDog/serilog-sinks-datadog-logs/pull/42/files#diff-391fbc7d1e0f1155c7b0c7bbc40cc3edc38918a8c7d3ac93646de32f3adef703L20-L23) remove an unused property.

`UTF8` was unused since `DatadogHttpClient.cs` was extracted from `DatadogClient.cs` in #24.