### PR TITLE
.NET 5 and .NET 6 support

### DIFF
--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -53,7 +53,7 @@ namespace Serilog
             TimeSpan? batchPeriod = null,
             int? queueLimit = null,
             Action<Exception> exceptionHandler = null,
-            bool detectTCPDisconnection = false)
+            bool detectTCPDisconnection = false, IDatadogClient client = null)
         {
             if (loggerConfiguration == null)
             {
@@ -65,7 +65,7 @@ namespace Serilog
             }
 
             var config = ApplyMicrosoftExtensionsConfiguration.ConfigureDatadogConfiguration(configuration, configurationSection);
-            var sink = DatadogSink.Create(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, queueLimit, exceptionHandler, detectTCPDisconnection);
+            var sink = DatadogSink.Create(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, queueLimit, exceptionHandler, detectTCPDisconnection, client);
 
             return loggerConfiguration.Sink(sink, logLevel);
         }

--- a/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
+++ b/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
@@ -29,7 +29,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
     <Compile Include="Configuration\Extensions\Microsoft.Extensions.Configuration\**\*.cs" />
     <Compile Include="Configuration\Implementations\Microsoft.Extensions.Configuration\**\*.cs" />

--- a/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
+++ b/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.3;net45;net461;net472</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.3;net45;net461;net472;net5.0;net6.0</TargetFrameworks>
     <AssemblyName>Serilog.Sinks.Datadog.Logs</AssemblyName>
     <PackageId>Serilog.Sinks.Datadog.Logs</PackageId>
     <PackageVersion>0.3.5</PackageVersion>
@@ -20,10 +20,13 @@
   <ItemGroup>
     <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="2.2.0" />
     <PackageReference Include="Serilog" Version="2.9.0" />
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <Compile Remove="Configuration\Extensions\Microsoft.Extensions.Configuration\**\*.*" />
     <Compile Remove="Configuration\Extensions\System.Configuration\**\*.*" />
     <Compile Remove="Configuration\Implementations\Microsoft.Extensions.Configuration\**\*.*" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'net6.0'">
+    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net461'">
@@ -36,7 +39,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0' And '$(TargetFramework)' != 'net472' And '$(TargetFramework)' != 'net461'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netstandard2.0' And '$(TargetFramework)' != 'net472' And '$(TargetFramework)' != 'net461' And '$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'net6.0'">
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <Compile Include="Configuration\Extensions\System.Configuration\**\*.cs" />
   </ItemGroup>

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
@@ -74,7 +74,7 @@ namespace Serilog.Sinks.Datadog.Logs
             var logEvents = new List<LogEvent>(events.Count());
             foreach (var logEvent in events)
             {
-                var formattedLog = _formatter.formatMessage(logEvent);
+                var formattedLog = _formatter.FormatMessage(logEvent);
                 var logSize = Encoding.UTF8.GetByteCount(formattedLog);
                 if (logSize > _maxMessageSize)
                 {

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -31,17 +31,17 @@ namespace Serilog.Sinks.Datadog.Logs
         /// </summary>
         private const int DefaultBatchSizeLimit = 50;
 
-        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, Action<Exception> exceptionHandler = null, bool detectTCPDisconnection = false)
+        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, Action<Exception> exceptionHandler = null, bool detectTCPDisconnection = false, IDatadogClient client = null)
             : base(batchSizeLimit ?? DefaultBatchSizeLimit, batchPeriod ?? DefaultBatchPeriod)
         {
-            _client = CreateDatadogClient(apiKey, source, service, host, tags, config, detectTCPDisconnection);
+            _client = client ?? CreateDatadogClient(apiKey, source, service, host, tags, config, detectTCPDisconnection);
             _exceptionHandler = exceptionHandler;
         }
 
-        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int queueLimit, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, Action<Exception> exceptionHandler = null, bool detectTCPDisconnection = false)
+        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int queueLimit, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, Action<Exception> exceptionHandler = null, bool detectTCPDisconnection = false, IDatadogClient client = null)
             : base(batchSizeLimit ?? DefaultBatchSizeLimit, batchPeriod ?? DefaultBatchPeriod, queueLimit)
         {
-            _client = CreateDatadogClient(apiKey, source, service, host, tags, config, detectTCPDisconnection);
+            _client = client ?? CreateDatadogClient(apiKey, source, service, host, tags, config, detectTCPDisconnection);
             _exceptionHandler = exceptionHandler;
         }
 
@@ -56,12 +56,12 @@ namespace Serilog.Sinks.Datadog.Logs
             TimeSpan? batchPeriod = null, 
             int? queueLimit = null, 
             Action<Exception> exceptionHandler = null, 
-            bool detectTCPDisconnection = false)
+            bool detectTCPDisconnection = false, IDatadogClient client = null)
         {
             if (queueLimit.HasValue)
-                return new DatadogSink(apiKey, source, service, host, tags, config, queueLimit.Value, batchSizeLimit, batchPeriod, exceptionHandler, detectTCPDisconnection);
+                return new DatadogSink(apiKey, source, service, host, tags, config, queueLimit.Value, batchSizeLimit, batchPeriod, exceptionHandler, detectTCPDisconnection, client);
 
-            return new DatadogSink(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, exceptionHandler, detectTCPDisconnection);
+            return new DatadogSink(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, exceptionHandler, detectTCPDisconnection, client);
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogTcpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogTcpClient.cs
@@ -92,7 +92,7 @@ namespace Serilog.Sinks.Datadog.Logs
             foreach (var logEvent in events)
             {
                 payloadBuilder.Append(_apiKey + WhiteSpace);
-                payloadBuilder.Append(_formatter.formatMessage(logEvent));
+                payloadBuilder.Append(_formatter.FormatMessage(logEvent));
                 payloadBuilder.Append(MessageDelimiter);
             }
             string payload = payloadBuilder.ToString();

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
@@ -48,7 +48,8 @@ namespace Serilog.Sinks.Datadog.Logs
         private static readonly JsonSerializerSettings settings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, Formatting = Newtonsoft.Json.Formatting.None };
 #endif
 
-        public LogFormatter(string source, string service, string host, string[] tags) {
+        public LogFormatter(string source, string service, string host, string[] tags)
+        {
             _source = source ?? CSHARP;
             _service = service;
             _host = host;
@@ -58,7 +59,8 @@ namespace Serilog.Sinks.Datadog.Logs
         /// <summary>
         /// formatMessage enrich the log event with DataDog metadata such as source, service, host and tags.
         /// </summary>
-        public string FormatMessage(LogEvent logEvent) {
+        public string FormatMessage(LogEvent logEvent)
+        {
             var payload = new StringBuilder();
             var writer = new StringWriter(payload);
 
@@ -95,8 +97,10 @@ namespace Serilog.Sinks.Datadog.Logs
         /// Renames a key in a dictionary.
         /// </summary>
         private void RenameKey<TKey, TValue>(IDictionary<TKey, TValue> dict,
-                                           TKey oldKey, TKey newKey) {
-            if (dict.TryGetValue(oldKey, out TValue value)) {
+                                           TKey oldKey, TKey newKey)
+        {
+            if (dict.TryGetValue(oldKey, out TValue value))
+            {
                 dict.Remove(oldKey);
                 dict.Add(newKey, value);
             }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
@@ -6,12 +6,12 @@
 using System.Text;
 using System.IO;
 using System.Collections.Generic;
-
 using Serilog.Events;
 using Serilog.Formatting.Json;
 #if NET5_0_OR_GREATER
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using System.Text.Encodings.Web;
 #else
 using Newtonsoft.Json;
 #endif
@@ -39,7 +39,7 @@ namespace Serilog.Sinks.Datadog.Logs
         /// <summary>
         /// Settings to drop null values.
         /// </summary>
-        private static readonly JsonSerializerOptions settings = new JsonSerializerOptions { WriteIndented = false, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull};
+        private static readonly JsonSerializerOptions settings = new JsonSerializerOptions { WriteIndented = false, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping};
 #else
 
         /// <summary>

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
@@ -6,9 +6,16 @@
 using System.Text;
 using System.IO;
 using System.Collections.Generic;
+
 using Serilog.Events;
 using Serilog.Formatting.Json;
+#if NET5_0_OR_GREATER
+using System.Text.Json;
+using System.Text.Json.Serialization;
+#else
 using Newtonsoft.Json;
+#endif
+
 namespace Serilog.Sinks.Datadog.Logs
 {
     public class LogFormatter
@@ -28,13 +35,20 @@ namespace Serilog.Sinks.Datadog.Logs
         /// </summary>
         private static readonly JsonFormatter formatter = new JsonFormatter(renderMessage: true);
 
+#if NET5_0_OR_GREATER
         /// <summary>
         /// Settings to drop null values.
         /// </summary>
-        private static readonly JsonSerializerSettings settings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore };
+        private static readonly JsonSerializerOptions settings = new JsonSerializerOptions { WriteIndented = false, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull};
+#else
 
-        public LogFormatter(string source, string service, string host, string[] tags)
-        {
+        /// <summary>
+        /// Settings to drop null values.
+        /// </summary>
+        private static readonly JsonSerializerSettings settings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, Formatting = Newtonsoft.Json.Formatting.None };
+#endif
+
+        public LogFormatter(string source, string service, string host, string[] tags) {
             _source = source ?? CSHARP;
             _service = service;
             _host = host;
@@ -44,8 +58,7 @@ namespace Serilog.Sinks.Datadog.Logs
         /// <summary>
         /// formatMessage enrich the log event with DataDog metadata such as source, service, host and tags.
         /// </summary>
-        public string formatMessage(LogEvent logEvent)
-        {
+        public string FormatMessage(LogEvent logEvent) {
             var payload = new StringBuilder();
             var writer = new StringWriter(payload);
 
@@ -54,9 +67,15 @@ namespace Serilog.Sinks.Datadog.Logs
             formatter.Format(logEvent, writer);
 
             // Convert the JSON to a dictionnary and add the DataDog properties
-            var logEventAsDict = JsonConvert.DeserializeObject<Dictionary<string, dynamic>>(payload.ToString());
+#if NET5_0_OR_GREATER
+
+            var logEventAsDict = JsonSerializer.Deserialize<Dictionary<string, object>>(payload.ToString());
+#else
+            var logEventAsDict = JsonConvert.DeserializeObject<Dictionary<string, object>>(payload.ToString());
+#endif
+
             if (_source != null) { logEventAsDict.Add("ddsource", _source); }
-            if (_service != null) { logEventAsDict.Add("service",_service); }
+            if (_service != null) { logEventAsDict.Add("service", _service); }
             if (_host != null) { logEventAsDict.Add("host", _host); }
             if (_tags != null) { logEventAsDict.Add("ddtags", _tags); }
 
@@ -64,19 +83,20 @@ namespace Serilog.Sinks.Datadog.Logs
             // displayed on the Log Explorer
             RenameKey(logEventAsDict, "RenderedMessage", "message");
             RenameKey(logEventAsDict, "Level", "level");
-
             // Convert back the dict to a JSON string
-            return JsonConvert.SerializeObject(logEventAsDict, Newtonsoft.Json.Formatting.None, settings);
+#if NET5_0_OR_GREATER
+    return JsonSerializer.Serialize(logEventAsDict, settings);
+#else
+            return JsonConvert.SerializeObject(logEventAsDict, settings);
+#endif
         }
 
         /// <summary>
         /// Renames a key in a dictionary.
         /// </summary>
         private void RenameKey<TKey, TValue>(IDictionary<TKey, TValue> dict,
-                                           TKey oldKey, TKey newKey)
-        {
-            if (dict.TryGetValue(oldKey, out TValue value))
-            {
+                                           TKey oldKey, TKey newKey) {
+            if (dict.TryGetValue(oldKey, out TValue value)) {
                 dict.Remove(oldKey);
                 dict.Add(newKey, value);
             }

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/FormatterTests.cs
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/FormatterTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Runtime;
+using NUnit.Framework;
+using Serilog.Events;
+
+namespace Serilog.Sinks.Datadog.Logs.Tests
+{
+    [TestFixture]
+    public class FormatterTests
+    {
+        [Test]
+        public void CanFormat()
+        {
+            var exception = new Exception("Top", new Exception("Middle", new ApplicationException("Bottom")));
+            var properties = new[]
+            {
+                new LogEventProperty("A", new ScalarValue(1)), new LogEventProperty("B", new DictionaryValue(new[]
+                {
+                    new KeyValuePair<ScalarValue, LogEventPropertyValue>(new ScalarValue(1), new ScalarValue(2))
+                }))
+            };
+
+
+            var logEvent = new LogEvent(DateTimeOffset.UtcNow, LogEventLevel.Information, exception, MessageTemplate.Empty, properties);
+
+            var formatter = new LogFormatter(null, "TEST", "localhost", new[] { "the", "coolest", "test" });
+            var message = formatter.FormatMessage(logEvent);
+            Assert.That(!string.IsNullOrWhiteSpace(message));
+        }
+    }
+}

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/FormatterTests.cs
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/FormatterTests.cs
@@ -10,11 +10,11 @@ namespace Serilog.Sinks.Datadog.Logs.Tests
         [Test]
         public void CanFormat()
         {
-        #if NET5_0_OR_GREATER
+#if NET5_0_OR_GREATER
             var ver = Environment.Version.ToString();
-        #else
+#else
             var ver = AppDomain.CurrentDomain.SetupInformation.TargetFrameworkName;
-        #endif
+#endif
             const string apiKey = "NOT_AN_API_KEY";
             var config = new DatadogConfiguration();
             var logFormatter = new LogFormatter(ver, "TEST", "localhost", new[] { "the", "coolest", "test" });
@@ -23,8 +23,8 @@ namespace Serilog.Sinks.Datadog.Logs.Tests
             {
                 var positions = new dynamic[]
                 {
-                    new { Latitude = byte.MinValue, Longitude = byte.MaxValue }, 
-                    new { Latitude = short.MinValue, Longitude = short.MaxValue }, 
+                    new { Latitude = byte.MinValue, Longitude = byte.MaxValue },
+                    new { Latitude = short.MinValue, Longitude = short.MaxValue },
                     new { Latitude = int.MinValue, Longitude = int.MaxValue },
                     new { Latitude = long.MinValue, Longitude = long.MaxValue }
                 };

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/NoopClient.cs
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/NoopClient.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Serilog.Events;
+
+namespace Serilog.Sinks.Datadog.Logs.Tests
+{
+    /// <summary>
+    /// A mock <see cref="IDatadogClient"/> that formats and writes logs to nowhere for the purpose of testing.
+    /// </summary>
+    public class NoopClient : IDatadogClient
+    {
+        private readonly string _apiKey;
+        private readonly LogFormatter _formatter;
+
+        public NoopClient(string apiKey, LogFormatter formatter) {
+            _apiKey = apiKey;
+            _formatter = formatter;
+        }
+
+        public Task WriteAsync(IEnumerable<LogEvent> events) {
+
+
+            var payloadBuilder = new StringBuilder();
+            Assert.DoesNotThrow(() => {
+               
+                foreach (var logEvent in events) {
+                    payloadBuilder.Append(_apiKey).Append(' ');
+                    var formatted = _formatter.FormatMessage(logEvent);
+                    Assert.IsNotEmpty(formatted);
+                    payloadBuilder.Append(formatted);
+                    payloadBuilder.Append('\n');
+                }
+            });
+            var payload = payloadBuilder.ToString();
+            Assert.IsNotEmpty(payload);
+
+
+            return Task.CompletedTask;
+        }
+
+        public void Close() {
+
+        }
+    }
+}

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/NoopClient.cs
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/NoopClient.cs
@@ -15,18 +15,21 @@ namespace Serilog.Sinks.Datadog.Logs.Tests
         private readonly string _apiKey;
         private readonly LogFormatter _formatter;
 
-        public NoopClient(string apiKey, LogFormatter formatter) {
+        public NoopClient(string apiKey, LogFormatter formatter)
+        {
             _apiKey = apiKey;
             _formatter = formatter;
         }
 
-        public Task WriteAsync(IEnumerable<LogEvent> events) {
+        public Task WriteAsync(IEnumerable<LogEvent> events)
+        {
 
 
             var payloadBuilder = new StringBuilder();
             Assert.DoesNotThrow(() => {
-               
-                foreach (var logEvent in events) {
+
+                foreach (var logEvent in events)
+                {
                     payloadBuilder.Append(_apiKey).Append(' ');
                     var formatted = _formatter.FormatMessage(logEvent);
                     Assert.IsNotEmpty(formatted);
@@ -41,7 +44,8 @@ namespace Serilog.Sinks.Datadog.Logs.Tests
             return Task.CompletedTask;
         }
 
-        public void Close() {
+        public void Close()
+        {
 
         }
     }

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/Serilog.Sinks.Datadog.Logs.Tests.csproj
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/Serilog.Sinks.Datadog.Logs.Tests.csproj
@@ -1,7 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+
+    <TargetFrameworks>net45;net461;net472;net5.0;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Serilog.Sinks.Datadog.Logs.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/Serilog.Sinks.Datadog.Logs.Tests.csproj
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/Serilog.Sinks.Datadog.Logs.Tests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
 
-    <TargetFrameworks>net45;net461;net472;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net461;net472;net5.0;net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Serilog.Sinks.Datadog.Logs.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>


### PR DESCRIPTION
This PR changes the log formatter so that it depends on [System.Text.Json](https://docs.microsoft.com/en-us/dotnet/api/system.text.json?view=net-5.0) rather than Newtonsoft.Json when .NET 5+ is the target runtime. Doing so yields a 90% performance boost in execution time over Newtonsoft.Json (Newtonsoft.Json is still used by .NET framework and standard targets to preserve their behavior.)


![image](https://user-images.githubusercontent.com/1297077/139365808-4467eba4-b755-48a3-b11b-84866d2a67bf.png)

I've also changed the type used for the payload from `Dictionary<string, dynamic>` to `Dictionary<string, object>`. It wasn't clear why dynamic was used, but the runtime overhead of dynamic when compared to boxing is noticeable.

To help with testing I've added an extra parameter on the sink to pass in an implementation of `IDatadogClient` which was already public.

Finally, this fixes an unnecessary reference to System.Http being added to .NET 5+ projects.  

A diff of the serialized log events shows they are 1:1 
![image](https://user-images.githubusercontent.com/1297077/139377116-43efec5e-b8eb-4b2a-8b95-fd3a182775bf.png)

