### PR TITLE
Optimizations

### DIFF
--- a/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
+++ b/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
@@ -25,10 +25,6 @@
     <Compile Remove="Configuration\Implementations\Microsoft.Extensions.Configuration\**\*.*" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0' And '$(TargetFramework)' != 'net6.0'">
-    <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-  </ItemGroup>
-
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' Or '$(TargetFramework)' == 'net472' Or '$(TargetFramework)' == 'net461' Or '$(TargetFramework)' == 'net5.0' Or '$(TargetFramework)' == 'net6.0'">
     <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="2.1.1" />
     <Compile Include="Configuration\Extensions\Microsoft.Extensions.Configuration\**\*.cs" />

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogConfiguration.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogConfiguration.cs
@@ -33,7 +33,7 @@ namespace Serilog.Sinks.Datadog.Logs
         /// <summary>
         /// Port of the server to send log events to.
         /// </summary>
-        public int Port { get; set;  }
+        public int Port { get; set; }
 
         /// <summary>
         /// Use SSL or plain text.
@@ -45,8 +45,7 @@ namespace Serilog.Sinks.Datadog.Logs
         /// </summary>
         public bool UseTCP { get; set; }
 
-        public DatadogConfiguration() : this(DDUrl, DDPort, true, false) {
-        }
+        public DatadogConfiguration() : this(DDUrl, DDPort, true, false) {}
 
         public DatadogConfiguration(string url = DDUrl, int port = DDPort, bool useSSL = true, bool useTCP = false)
         {

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogConfiguration.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogConfiguration.cs
@@ -49,14 +49,15 @@ namespace Serilog.Sinks.Datadog.Logs
         /// </summary>
         public bool RecycleResources { get; set;}
 
-        public DatadogConfiguration() : this(DDUrl, DDPort, true, false) {}
+        public DatadogConfiguration() : this(DDUrl, DDPort, true, false, false) {}
 
-        public DatadogConfiguration(string url = DDUrl, int port = DDPort, bool useSSL = true, bool useTCP = false)
+        public DatadogConfiguration(string url = DDUrl, int port = DDPort, bool useSSL = true, bool useTCP = false, bool recycleResources = false)
         {
             Url = url;
             Port = port;
             UseSSL = useSSL;
             UseTCP = useTCP;
+            RecycleResources = recycleResources;
         }
 
         public override string ToString()

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogConfiguration.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogConfiguration.cs
@@ -44,6 +44,10 @@ namespace Serilog.Sinks.Datadog.Logs
         /// Use TCP or HTTP.
         /// </summary>
         public bool UseTCP { get; set; }
+        /// <summary>
+        /// When set to true the sink priotizes memory usage over throughput. 
+        /// </summary>
+        public bool RecycleResources { get; set;}
 
         public DatadogConfiguration() : this(DDUrl, DDPort, true, false) {}
 

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogFormatter.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogFormatter.cs
@@ -89,13 +89,13 @@ namespace Serilog.Sinks.Datadog.Logs.Sinks.Datadog
                     switch (property.Key)
                     {
                         case "ddservice":
-                            WriteRawJsonProperty("service", property.Value, ref delim, output);
+                            WriteJsonProperty("service", property.Value, ref delim, output);
                             break;
                         case "ddhost":
-                            WriteRawJsonProperty("host", property.Value, ref delim, output);
+                            WriteJsonProperty("host", property.Value, ref delim, output);
                             break;
                         default:
-                            WriteRawJsonProperty(property.Key, property.Value, ref delim, output);
+                            WriteJsonProperty(property.Key, property.Value, ref delim, output);
                             break;
                     }
                 }
@@ -176,7 +176,7 @@ namespace Serilog.Sinks.Datadog.Logs.Sinks.Datadog
         }
 
 
-        static void WriteLiteral<TType>(TType value, TextWriter output, bool forceQuotation = false)
+        static void WriteLiteral(object value, TextWriter output, bool forceQuotation = false)
         {
             if (value == null)
             {
@@ -184,11 +184,12 @@ namespace Serilog.Sinks.Datadog.Logs.Sinks.Datadog
                 return;
             }
 
-            if (_literalWriters.TryGetValue(typeof(TType), out var writer))
+            if (_literalWriters.TryGetValue(value.GetType(), out var writer))
             {
                 writer(value, forceQuotation, output);
                 return;
             }
+
             WriteString(value.ToString() ?? "", output);
         }
 
@@ -206,18 +207,7 @@ namespace Serilog.Sinks.Datadog.Logs.Sinks.Datadog
             output.Write("}");
         }
 
-        static void WriteRawJsonProperty(string name, LogEventPropertyValue value, ref string precedingDelimiter, TextWriter output)
-        {
-            output.Write(precedingDelimiter);
-            output.Write("\"");
-            output.Write(name);
-            output.Write("\":");
-            WriteString(value.ToString() ?? "", output, false);
-            precedingDelimiter = ",";
-        }
-
-
-        static void WriteJsonProperty<TType>(string name, TType value, ref string precedingDelimiter, TextWriter output)
+        static void WriteJsonProperty(string name, object value, ref string precedingDelimiter, TextWriter output)
         {
             output.Write(precedingDelimiter);
             output.Write("\"");

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogFormatter.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogFormatter.cs
@@ -1,0 +1,314 @@
+﻿using Serilog.Events;
+using Serilog.Formatting;
+using Serilog.Formatting.Json;
+using Serilog.Parsing;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Linq;
+using System.Text;
+
+namespace Serilog.Sinks.Datadog.Logs.Sinks.Datadog
+{
+    /// <summary>
+    /// Formats log events in a simple JSON structure in accordance with the expected structure expected by the Datadog API. Instances of this class
+    /// are safe for concurrent access by multiple threads.
+    /// </summary>
+    internal class DatadogFormatter : ITextFormatter
+    {
+        private static readonly HashSet<string> SpecialProperties = new HashSet<string>() { "ddsource", "ddservice", "ddhost", "ddtags" };
+
+        private static readonly IDictionary<Type, Action<object, bool, TextWriter>> _literalWriters = new Dictionary<Type, Action<object, bool, TextWriter>>
+            {
+                { typeof(bool), (v, _, w) => WriteBoolean((bool)v, w) },
+                { typeof(char), (v, _, w) => WriteString(((char)v).ToString(), w) },
+                { typeof(byte), WriteToString },
+                { typeof(sbyte), WriteToString },
+                { typeof(short), WriteToString },
+                { typeof(ushort), WriteToString },
+                { typeof(int), WriteToString },
+                { typeof(uint), WriteToString },
+                { typeof(long), WriteToString },
+                { typeof(ulong), WriteToString },
+                { typeof(float), (v, _, w) => WriteSingle((float)v, w) },
+                { typeof(double), (v, _, w) => WriteDouble((double)v, w) },
+                { typeof(decimal), WriteToString },
+                { typeof(string), (v, _, w) => WriteString((string)v, w) },
+                { typeof(DateTime), (v, _, w) => WriteDateTime((DateTime)v, w) },
+                { typeof(DateTimeOffset), (v, _, w) => WriteOffset((DateTimeOffset)v, w) },
+                { typeof(ScalarValue), (v, q, w) => WriteLiteral(((ScalarValue)v).Value, w, q) },
+                { typeof(SequenceValue), (v, _, w) => WriteSequence(((SequenceValue)v).Elements, w) },
+                { typeof(DictionaryValue), (v, _, w) => WriteDictionary(((DictionaryValue)v).Elements, w) },
+                { typeof(StructureValue), (v, _, w) => WriteStructure(((StructureValue)v).TypeTag, ((StructureValue)v).Properties, w) },
+            };
+        private readonly bool _renderMessage;
+
+        public DatadogFormatter(bool renderMessage)
+        {
+            _renderMessage = renderMessage;
+
+        }
+
+        /// <summary>
+        /// Format the log event into the output.
+        /// </summary>
+        /// <param name="logEvent">The event to format.</param>
+        /// <param name="output">The output.</param>
+        /// <exception cref="ArgumentNullException">When <paramref name="logEvent"/> is <code>null</code></exception>
+        /// <exception cref="ArgumentNullException">When <paramref name="output"/> is <code>null</code></exception>
+        public void Format(LogEvent logEvent, TextWriter output)
+        {
+            if (logEvent == null) throw new ArgumentNullException(nameof(logEvent));
+            if (output == null) throw new ArgumentNullException(nameof(output));
+
+            output.Write("{");
+
+            var delim = "";
+            WriteJsonProperty("Timestamp", logEvent.Timestamp, ref delim, output);
+            WriteJsonProperty("level", logEvent.Level, ref delim, output);
+
+            WriteJsonProperty("MessageTemplate", logEvent.MessageTemplate, ref delim, output);
+            if (_renderMessage)
+            {
+                var message = logEvent.RenderMessage();
+                WriteJsonProperty("message", message, ref delim, output);
+            }
+
+            if (logEvent.Exception != null)
+            {
+                WriteJsonProperty("Exception", logEvent.Exception, ref delim, output);
+            }
+
+
+            if (logEvent.Properties.Count != 0)
+            {
+                foreach (var property in logEvent.Properties.Where(p => SpecialProperties.Contains(p.Key)))
+                {
+                    switch (property.Key)
+                    {
+                        case "ddservice":
+                            WriteRawJsonProperty("service", property.Value, ref delim, output);
+                            break;
+                        case "ddhost":
+                            WriteRawJsonProperty("host", property.Value, ref delim, output);
+                            break;
+                        default:
+                            WriteRawJsonProperty(property.Key, property.Value, ref delim, output);
+                            break;
+                    }
+                }
+                WriteProperties(logEvent.Properties.Where(p => !SpecialProperties.Contains(p.Key)), output);
+            }
+
+            var tokensWithFormat = logEvent.MessageTemplate.Tokens
+                .OfType<PropertyToken>()
+                .Where(pt => pt.Format != null)
+                .GroupBy(pt => pt.PropertyName)
+                .ToArray();
+
+            if (tokensWithFormat.Length != 0)
+            {
+                WriteRenderings(tokensWithFormat, logEvent.Properties, output);
+            }
+
+            output.Write("}");
+            output.Write(Environment.NewLine);
+
+        }
+
+        static void WriteProperties(IEnumerable<KeyValuePair<string, LogEventPropertyValue>> properties, TextWriter output)
+        {
+            output.Write(",\"{0}\":{{", "Properties");
+            WritePropertiesValues(properties, output);
+            output.Write("}");
+        }
+
+        static void WriteRenderings(IGrouping<string, PropertyToken>[] tokensWithFormat, IReadOnlyDictionary<string, LogEventPropertyValue> properties, TextWriter output)
+        {
+            output.Write(",\"{0}\":{{", "Renderings");
+            WriteRenderingsValues(tokensWithFormat, properties, output);
+            output.Write("}");
+        }
+
+        static void WriteRenderingsValues(IGrouping<string, PropertyToken>[] tokensWithFormat, IReadOnlyDictionary<string, LogEventPropertyValue> properties, TextWriter output)
+        {
+            var rdelim = "";
+            foreach (var ptoken in tokensWithFormat)
+            {
+                output.Write(rdelim);
+                rdelim = ",";
+                output.Write("\"");
+                output.Write(ptoken.Key);
+                output.Write("\":[");
+
+                var fdelim = "";
+                foreach (var format in ptoken)
+                {
+                    output.Write(fdelim);
+                    fdelim = ",";
+
+                    output.Write("{");
+                    var eldelim = "";
+
+                    WriteJsonProperty("Format", format.Format, ref eldelim, output);
+
+                    var sw = new StringWriter();
+                    format.Render(properties, sw);
+                    WriteJsonProperty("Rendering", sw.ToString(), ref eldelim, output);
+
+                    output.Write("}");
+                }
+
+                output.Write("]");
+            }
+        }
+
+
+        static void WritePropertiesValues(IEnumerable<KeyValuePair<string, LogEventPropertyValue>> properties, TextWriter output)
+        {
+            var precedingDelimiter = "";
+            foreach (var property in properties)
+            {
+                WriteJsonProperty(property.Key, property.Value, ref precedingDelimiter, output);
+            }
+        }
+
+
+        static void WriteLiteral<TType>(TType value, TextWriter output, bool forceQuotation = false)
+        {
+            if (value == null)
+            {
+                output.Write("null");
+                return;
+            }
+
+            if (_literalWriters.TryGetValue(typeof(TType), out var writer))
+            {
+                writer(value, forceQuotation, output);
+                return;
+            }
+            WriteString(value.ToString() ?? "", output);
+        }
+
+        static void WriteStructure(string typeTag, IEnumerable<LogEventProperty> properties, TextWriter output)
+        {
+            output.Write("{");
+
+            var delim = "";
+            if (typeTag != null)
+                WriteJsonProperty("_typeTag", typeTag, ref delim, output);
+
+            foreach (var property in properties)
+                WriteJsonProperty(property.Name, property.Value, ref delim, output);
+
+            output.Write("}");
+        }
+
+        static void WriteRawJsonProperty(string name, LogEventPropertyValue value, ref string precedingDelimiter, TextWriter output)
+        {
+            output.Write(precedingDelimiter);
+            output.Write("\"");
+            output.Write(name);
+            output.Write("\":");
+            WriteString(value.ToString() ?? "", output, false);
+            precedingDelimiter = ",";
+        }
+
+
+        static void WriteJsonProperty<TType>(string name, TType value, ref string precedingDelimiter, TextWriter output)
+        {
+            output.Write(precedingDelimiter);
+            output.Write("\"");
+            output.Write(name);
+            output.Write("\":");
+            WriteLiteral(value, output);
+            precedingDelimiter = ",";
+        }
+
+        static void WriteSequence(IEnumerable elements, TextWriter output)
+        {
+            output.Write("[");
+            var delim = "";
+            foreach (var value in elements)
+            {
+                output.Write(delim);
+                delim = ",";
+                WriteLiteral(value, output);
+            }
+            output.Write("]");
+        }
+
+        static void WriteDictionary(IReadOnlyDictionary<ScalarValue, LogEventPropertyValue> elements, TextWriter output)
+        {
+            output.Write("{");
+            var delim = "";
+            foreach (var element in elements)
+            {
+                output.Write(delim);
+                delim = ",";
+                WriteLiteral(element.Key, output, forceQuotation: true);
+                output.Write(":");
+                WriteLiteral(element.Value, output);
+            }
+            output.Write("}");
+        }
+
+        static void WriteToString(object number, bool quote, TextWriter output)
+        {
+            if (quote) output.Write('"');
+
+            if (number is IFormattable fmt)
+                output.Write(fmt.ToString(null, CultureInfo.InvariantCulture));
+            else
+                output.Write(number.ToString());
+
+            if (quote) output.Write('"');
+        }
+
+        static void WriteBoolean(bool value, TextWriter output)
+        {
+            output.Write(value ? "true" : "false");
+        }
+
+        static void WriteSingle(float value, TextWriter output)
+        {
+            output.Write(value.ToString("R", CultureInfo.InvariantCulture));
+        }
+
+        static void WriteDouble(double value, TextWriter output)
+        {
+            output.Write(value.ToString("R", CultureInfo.InvariantCulture));
+        }
+
+        static void WriteOffset(DateTimeOffset value, TextWriter output)
+        {
+            output.Write("\"");
+            output.Write(value.ToString("o"));
+            output.Write("\"");
+        }
+
+        static void WriteDateTime(DateTime value, TextWriter output)
+        {
+            output.Write("\"");
+            output.Write(value.ToString("o"));
+            output.Write("\"");
+        }
+
+
+
+        static void WriteString(string value, TextWriter output, bool quote = true)
+        {
+            if (quote)
+            {
+                JsonValueFormatter.WriteQuotedJsonString(value, output);
+            }
+            else
+            {
+                output.Write(value);
+            }
+        }
+
+    }
+}

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
@@ -80,7 +80,7 @@ namespace Serilog.Sinks.Datadog.Logs
                         break;
                     }
                     var formattedLog = _formatter.FormatMessage(events[i]);
-                    var logSize = Encoding.UTF8.GetMaxByteCount(formattedLog.Length);
+                    var logSize = Encoding.UTF8.GetByteCount(formattedLog);
                     if (logSize > _maxMessageSize)
                     {
                         if (onException != null)

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
@@ -168,7 +168,7 @@ namespace Serilog.Sinks.Datadog.Logs
 
         public void Dispose()
         {
-              _cancellationTokenSource.Cancel();
+            _cancellationTokenSource.Cancel();
             if (_client != null)
             {
                 _client.Dispose();

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -97,7 +97,7 @@ namespace Serilog.Sinks.Datadog.Logs
                 }
                 if (_recycleResources)
                 {
-                    await Semaphore.WaitAsync(_cancellationToken);
+                    await Semaphore.WaitAsync(_cancellationToken).ConfigureAwait(false);
                 }
                 var logEvents = events.ToArray();
                 await _client.WriteAsync(logEvents, _exceptionHandler).ConfigureAwait(false);

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -118,7 +118,7 @@ namespace Serilog.Sinks.Datadog.Logs
             var logFormatter = new LogFormatter(source, service, host, tags);
             if (configuration.UseTCP)
             {
-                return new DatadogTcpClient(configuration, logFormatter, apiKey, detectTCPDisconnection);
+                return new DatadogTcpClient(configuration, logFormatter, apiKey, detectTCPDisconnection, cancellationToken);
             }
             else
             {

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -122,21 +122,19 @@ namespace Serilog.Sinks.Datadog.Logs
             {
                 // delay the dispose by one batch period so lingering events get logged. 
                 // after that the dispose thread will enter and block any further writes.
-                _ = Task.Delay(DefaultBatchPeriod).ContinueWith(_ => {
-                    try
-                    {
-                        Semaphore.Wait(_cancellationToken);
-                        _cancellationTokenSource.Cancel();
-                        _client.Dispose();
-                        base.Dispose(disposing);
+                try
+                {
+                    Semaphore.Wait(_cancellationToken);
+                    _cancellationTokenSource.Cancel();
+                    _client.Dispose();
+                    base.Dispose(disposing);
 
-                    } finally
-                    {
-                        Semaphore.Release();
-                        Semaphore.Dispose();
-                        _cancellationTokenSource.Dispose();
-                    }
-                }, CancellationToken.None);
+                } finally
+                {
+                    Semaphore.Release();
+                    Semaphore.Dispose();
+                    _cancellationTokenSource.Dispose();
+                }
             }
         }
 

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -83,7 +83,8 @@ namespace Serilog.Sinks.Datadog.Logs
         /// </remarks>
         protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)
         {
-            if (_cancellationToken.IsCancellationRequested) {
+            if (_cancellationToken.IsCancellationRequested)
+            {
                 return;
             }
             try
@@ -119,9 +120,9 @@ namespace Serilog.Sinks.Datadog.Logs
         {
             if (disposing)
             {
-               // delay the dispose by one batch period so lingering events get logged. 
-               // after that the dispose thread will enter and block any further writes.
-               _ = Task.Delay(DefaultBatchPeriod).ContinueWith(_ => {
+                // delay the dispose by one batch period so lingering events get logged. 
+                // after that the dispose thread will enter and block any further writes.
+                _ = Task.Delay(DefaultBatchPeriod).ContinueWith(_ => {
                     try
                     {
                         Semaphore.Wait(_cancellationToken);

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -145,7 +145,15 @@ namespace Serilog.Sinks.Datadog.Logs
                 {
                     if (_recycleResources)
                     {
-                        Semaphore.Release();
+                        try
+                        {
+                            Semaphore.Release();
+                        }
+                        catch
+                        {
+
+                           //NOOP
+                        }
                         Semaphore.Dispose();
                     }
                     _cancellationTokenSource.Dispose();

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -78,6 +78,9 @@ namespace Serilog.Sinks.Datadog.Logs
         /// Emit a batch of log events to Datadog logs-backend.
         /// </summary>
         /// <param name="events">The events to emit.</param>
+        /// <remarks>
+        /// Only a single batch is able to be on the wire at a time. This ensures resources can be recycled per-batch.
+        /// </remarks>
         protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)
         {
             if (_cancellationToken.IsCancellationRequested) {
@@ -133,9 +136,6 @@ namespace Serilog.Sinks.Datadog.Logs
                         _cancellationTokenSource.Dispose();
                     }
                 }, CancellationToken.None);
-            } else
-            {
-                
             }
         }
 

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -81,7 +81,7 @@ namespace Serilog.Sinks.Datadog.Logs
         /// </summary>
         /// <param name="events">The events to emit.</param>
         /// <remarks>
-        /// Only a single batch is able to be on the wire at a time. This ensures resources can be recycled per-batch.
+        /// When <see cref="DatadogConfiguration.RecycleResources"/> is true, only a single batch is able to be on the wire at a time. This ensures resources can be recycled per-batch.
         /// </remarks>
         protected override async Task EmitBatchAsync(IEnumerable<LogEvent> events)
         {
@@ -131,10 +131,10 @@ namespace Serilog.Sinks.Datadog.Logs
                 try
                 {
                     // delay the dispose by one batch period so lingering events get logged. 
-                    // after that the dispose thread will enter and block any further writes.
                     Task.Delay(DefaultBatchPeriod, _cancellationToken).Wait(_cancellationToken);
                     if (_recycleResources)
                     {
+                        // after that the dispose thread will enter and block any further writes.
                         Semaphore.Wait(_cancellationToken);
                     }
                     _cancellationTokenSource.Cancel();

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -120,10 +120,12 @@ namespace Serilog.Sinks.Datadog.Logs
         {
             if (disposing)
             {
-                // delay the dispose by one batch period so lingering events get logged. 
-                // after that the dispose thread will enter and block any further writes.
+               
                 try
                 {
+                    // delay the dispose by one batch period so lingering events get logged. 
+                    // after that the dispose thread will enter and block any further writes.
+                    Task.Delay(DefaultBatchPeriod, _cancellationToken).Wait(_cancellationToken);
                     Semaphore.Wait(_cancellationToken);
                     _cancellationTokenSource.Cancel();
                     _client.Dispose();

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogTcpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogTcpClient.cs
@@ -89,8 +89,7 @@ namespace Serilog.Sinks.Datadog.Logs
                 SslStream secureStream = new SslStream(rawStream);
                 await secureStream.AuthenticateAsClientAsync(_config.Url).ConfigureAwait(false);
                 _stream = secureStream;
-            }
-            else
+            } else
             {
                 _stream = rawStream;
             }
@@ -124,10 +123,9 @@ namespace Serilog.Sinks.Datadog.Logs
                     try
                     {
                         await ConnectAsync().ConfigureAwait(false);
-                    }
-                    catch (Exception e)
+                    } catch (Exception e)
                     {
-                       
+
                         SelfLog.WriteLine("Could not connect to Datadog: {0}", e);
                         if (e is OperationCanceledException)
                         {
@@ -142,8 +140,7 @@ namespace Serilog.Sinks.Datadog.Logs
                     byte[] data = UTF8.GetBytes(payload);
                     await _stream.WriteAsync(data, 0, data.Length, _cancellationToken).ConfigureAwait(false);
                     return;
-                }
-                catch (Exception e)
+                } catch (Exception e)
                 {
                     CloseConnection();
                     SelfLog.WriteLine("Could not send data to Datadog: {0}", e);
@@ -180,8 +177,7 @@ namespace Serilog.Sinks.Datadog.Logs
                 try
                 {
                     connections = IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpConnections();
-                }
-                catch (NotImplementedException)
+                } catch (NotImplementedException)
                 {
                     // Happen when using Mono on MacOs. Keep the same behavior as before.
                     return false;
@@ -220,8 +216,7 @@ namespace Serilog.Sinks.Datadog.Logs
                 try
                 {
                     _stream.Flush();
-                }
-                catch (Exception e)
+                } catch (Exception e)
                 {
                     SelfLog.WriteLine("Could not flush the remaining data: {0}", e);
                 }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogTcpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogTcpClient.cs
@@ -60,7 +60,7 @@ namespace Serilog.Sinks.Datadog.Logs
         private readonly CancellationTokenSource _cancellationTokenSource;
         private readonly CancellationToken _cancellationToken;
 
-        public DatadogTcpClient(DatadogConfiguration config, LogFormatter formatter, string apiKey, bool detectTCPDisconnection, CancellationToken token)
+        public DatadogTcpClient(DatadogConfiguration config, LogFormatter formatter, string apiKey, bool detectTCPDisconnection, bool recycleResources, CancellationToken token)
         {
             _cancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(token);
             _cancellationToken = _cancellationTokenSource.Token;

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogTcpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogTcpClient.cs
@@ -35,12 +35,12 @@ namespace Serilog.Sinks.Datadog.Logs
         /// <summary>
         /// API Key / message-content delimiter.
         /// </summary>
-        private const string WhiteSpace = " ";
+        private const char WhiteSpace = ' ';
 
         /// <summary>
         /// Message delimiter.
         /// </summary>
-        private const string MessageDelimiter = "\n";
+        private const char MessageDelimiter = '\n';
 
         /// <summary>
         /// Max number of retries when sending failed.
@@ -97,8 +97,8 @@ namespace Serilog.Sinks.Datadog.Logs
             var payloadBuilder = new StringBuilder();
             foreach (var logEvent in events)
             {
-                payloadBuilder.Append(_apiKey + WhiteSpace);
-                payloadBuilder.Append(_formatter.FormatMessage(logEvent));
+                payloadBuilder.Append(_apiKey).Append(WhiteSpace);
+                payloadBuilder.Append(_formatter.formatMessage(logEvent));
                 payloadBuilder.Append(MessageDelimiter);
             }
             var payload = payloadBuilder.ToString();

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/Exceptions/CannotSendLogEventException.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/Exceptions/CannotSendLogEventException.cs
@@ -5,12 +5,13 @@
 
 using Serilog.Events;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 
 namespace Serilog.Sinks.Datadog.Logs
 {
     public class CannotSendLogEventException : LogEventException
     {
-        public CannotSendLogEventException(string payload, IEnumerable<LogEvent> logEvents)
+        public CannotSendLogEventException(string payload, IReadOnlyCollection<LogEvent> logEvents)
             : base($"Could not send payload to Datadog: {payload}", logEvents)
         {
         }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/Exceptions/LogEventException.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/Exceptions/LogEventException.cs
@@ -11,12 +11,12 @@ namespace Serilog.Sinks.Datadog.Logs
 {
     public class LogEventException : Exception
     {
-        public LogEventException(string message, IEnumerable<LogEvent> logEvents)
+        public LogEventException(string message, IReadOnlyCollection<LogEvent> logEvents)
             : base(message)
         {
             LogEvents = logEvents;
         }
 
-        public IEnumerable<LogEvent> LogEvents { get; }
+        public IReadOnlyCollection<LogEvent> LogEvents { get; }
     }
 }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/Exceptions/TooBigLogEventException.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/Exceptions/TooBigLogEventException.cs
@@ -10,8 +10,13 @@ namespace Serilog.Sinks.Datadog.Logs
 {
     public class TooBigLogEventException : LogEventException
     {
-        public TooBigLogEventException(IEnumerable<LogEvent> logEvents)
+        public TooBigLogEventException(IReadOnlyCollection<LogEvent> logEvents)
             : base($"The LogEvent instances are too big to be sent.", logEvents)
+        {
+        }
+
+        public TooBigLogEventException(LogEvent logEvent)
+            : base($"The LogEvent instance is too big to be sent.", new[] { logEvent })
         {
         }
     }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/IDatadogClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/IDatadogClient.cs
@@ -10,13 +10,14 @@ using Serilog.Events;
 
 namespace Serilog.Sinks.Datadog.Logs
 {
-    public interface IDatadogClient
+    public interface IDatadogClient : IDisposable
     {
         /// <summary>
         /// Send payload to Datadog logs-backend.
         /// </summary>
         /// <param name="events">Serilog events to send.</param>
-        Task WriteAsync(IEnumerable<LogEvent> events);
+        /// <param name="onException">A callback that is invoked whenever the client fails to write events.</param>
+        Task WriteAsync(LogEvent[] events, Action<Exception> onException);
 
         /// <summary>
         /// Cleanup existing resources.

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
@@ -62,6 +62,11 @@ namespace Serilog.Sinks.Datadog.Logs
             } finally
             {
                 builder.Clear();
+                // remove properties incase other sinks are being used.
+                logEvent.RemovePropertyIfPresent("ddsource");
+                logEvent.RemovePropertyIfPresent("ddservice");
+                logEvent.RemovePropertyIfPresent("ddhost");
+                logEvent.RemovePropertyIfPresent("ddtags");
             }
         }
     }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
@@ -74,7 +74,7 @@ namespace Serilog.Sinks.Datadog.Logs
                 // Convert the JSON to a dictionnary and add the DataDog properties
 #if NET5_0_OR_GREATER
 
-                    var logEventAsDict = JsonSerializer.Deserialize<Dictionary<string, object>>(_payloadBuilder.ToString());
+                var logEventAsDict = JsonSerializer.Deserialize<Dictionary<string, object>>(_payloadBuilder.ToString());
 #else
                 var logEventAsDict = JsonConvert.DeserializeObject<Dictionary<string, object>>(_payloadBuilder.ToString());
 #endif
@@ -90,7 +90,7 @@ namespace Serilog.Sinks.Datadog.Logs
                 RenameKey(logEventAsDict, "Level", "level");
                 // Convert back the dict to a JSON string
 #if NET5_0_OR_GREATER
-                    return JsonSerializer.Serialize(logEventAsDict, settings);
+                return JsonSerializer.Serialize(logEventAsDict, settings);
 #else
                 return JsonConvert.SerializeObject(logEventAsDict, settings);
 #endif

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
@@ -12,10 +12,10 @@ namespace Serilog.Sinks.Datadog.Logs
 {
     public class LogFormatter
     {
-        private readonly ScalarValue _source;
-        private readonly ScalarValue _service;
-        private readonly ScalarValue _host;
-        private readonly ScalarValue _tags;
+        private readonly LogEventProperty _source;
+        private readonly LogEventProperty _service;
+        private readonly LogEventProperty _host;
+        private readonly LogEventProperty _tags;
         private readonly bool _recycleResources;
         private const int _maxSize = 2 * 1024 * 1024 - 51;  // Need to reserve space for at most 49 "," and "[" + "]"
         private static readonly StringBuilder _payloadBuilder = new StringBuilder(_maxSize, _maxSize);
@@ -31,10 +31,10 @@ namespace Serilog.Sinks.Datadog.Logs
 
         public LogFormatter(string source, string service, string host, string[] tags, bool recycleResources)
         {
-            _source = new ScalarValue(source ?? CSHARP);
-            _service = string.IsNullOrWhiteSpace(service) ? null : new ScalarValue(service);
-            _host = string.IsNullOrWhiteSpace(host) ?  null : new ScalarValue(host);
-            _tags = tags == null || tags.Length == 0 ? null : new ScalarValue(string.Join(",", tags));
+            _source = new LogEventProperty("ddsource", new ScalarValue(source ?? CSHARP));
+            _service = string.IsNullOrWhiteSpace(service) ? null : new LogEventProperty("ddservice", new ScalarValue(service));
+            _host = string.IsNullOrWhiteSpace(host) ?  null : new LogEventProperty("ddhost", new ScalarValue(host));
+            _tags = tags == null || tags.Length == 0 ? null : new LogEventProperty("ddtags", new ScalarValue(string.Join(",", tags)));
             _recycleResources = recycleResources;
             if (_recycleResources)
             {
@@ -50,10 +50,10 @@ namespace Serilog.Sinks.Datadog.Logs
             var builder = _recycleResources ? _payloadBuilder : new StringBuilder();
             try
             {
-                if (_source != null) { logEvent.AddPropertyIfAbsent(new LogEventProperty("ddsource", new ScalarValue(_source))); }
-                if (_service != null) { logEvent.AddPropertyIfAbsent(new LogEventProperty("ddservice", new ScalarValue(_service))); }
-                if (_host != null) { logEvent.AddPropertyIfAbsent(new LogEventProperty("ddhost", new ScalarValue(_host))); }
-                if (_tags != null) { logEvent.AddPropertyIfAbsent(new LogEventProperty("ddtags", new ScalarValue(_tags))); }
+                logEvent.AddPropertyIfAbsent(_source);
+                if (_service != null) { logEvent.AddPropertyIfAbsent(_service); }
+                if (_host != null) { logEvent.AddPropertyIfAbsent(_host); }
+                if (_tags != null) { logEvent.AddPropertyIfAbsent(_tags); }
                 var writer = new StringWriter(builder);
                 // Serialize the event as JSON. The Serilog formatter handles the
                 // internal structure of the logEvent to give a nicely formatted JSON

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/FormatterTests.cs
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/FormatterTests.cs
@@ -17,7 +17,7 @@ namespace Serilog.Sinks.Datadog.Logs.Tests
 #endif
             const string apiKey = "NOT_AN_API_KEY";
             var config = new DatadogConfiguration();
-            var logFormatter = new LogFormatter(ver, "TEST", "localhost", new[] { "the", "coolest", "test" });
+            var logFormatter = new LogFormatter(ver, "TEST", "localhost", new[] { "the", "coolest", "test" }, true);
             var noop = new NoopClient(apiKey, logFormatter);
             using (var log = new LoggerConfiguration().WriteTo.DatadogLogs(apiKey, configuration: config, client: noop).CreateLogger())
             {

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/FormatterTests.cs
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/FormatterTests.cs
@@ -29,10 +29,10 @@ namespace Serilog.Sinks.Datadog.Logs.Tests
                     new { Latitude = long.MinValue, Longitude = long.MaxValue }
                 };
                 const int elapsedMs = 34;
-                Assert.DoesNotThrow(() => log.Information("Processed {@Positions} in {Elapsed:000} ms.", new Dictionary<string, object>
+                Assert.DoesNotThrow(() => log.Information("Processed {@Positions} in {Elapsed:000} ms.", new
                 {
-                    { "positions", positions },
-                    { "creator", "ACME" }
+                    positions,
+                    creator = "ACME"
                 }, elapsedMs));
             }
         }

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/NoopClient.cs
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/NoopClient.cs
@@ -21,7 +21,7 @@ namespace Serilog.Sinks.Datadog.Logs.Tests
             _formatter = formatter;
         }
 
-        public Task WriteAsync(IEnumerable<LogEvent> events)
+        public Task WriteAsync(IEnumerable<LogEvent> events, Action<Exception> onException)
         {
 
 
@@ -47,6 +47,11 @@ namespace Serilog.Sinks.Datadog.Logs.Tests
         public void Close()
         {
 
+        }
+
+        public void Dispose()
+        {
+            
         }
     }
 }

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/NoopClient.cs
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/NoopClient.cs
@@ -40,7 +40,7 @@ namespace Serilog.Sinks.Datadog.Logs.Tests
             var payload = payloadBuilder.ToString();
             Assert.IsNotEmpty(payload);
 
-
+            Console.WriteLine(payload);
             return Task.CompletedTask;
         }
 

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/NoopClient.cs
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/NoopClient.cs
@@ -23,13 +23,12 @@ namespace Serilog.Sinks.Datadog.Logs.Tests
 
         public Task WriteAsync(LogEvent[] events, Action<Exception> onException)
         {
-
-
             var payloadBuilder = new StringBuilder();
             Assert.DoesNotThrow(() => {
 
                 foreach (var logEvent in events)
                 {
+                  
                     payloadBuilder.Append(_apiKey).Append(' ');
                     var formatted = _formatter.FormatMessage(logEvent);
                     Assert.IsNotEmpty(formatted);
@@ -39,8 +38,6 @@ namespace Serilog.Sinks.Datadog.Logs.Tests
             });
             var payload = payloadBuilder.ToString();
             Assert.IsNotEmpty(payload);
-
-            Console.WriteLine(payload);
             return Task.CompletedTask;
         }
 

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/NoopClient.cs
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/NoopClient.cs
@@ -21,7 +21,7 @@ namespace Serilog.Sinks.Datadog.Logs.Tests
             _formatter = formatter;
         }
 
-        public Task WriteAsync(IEnumerable<LogEvent> events, Action<Exception> onException)
+        public Task WriteAsync(LogEvent[] events, Action<Exception> onException)
         {
 
 


### PR DESCRIPTION
This PR addresses a few memory leaks and aims to reduce runtime allocations. Here are some of the changes:
- Await individual task directly rather than allocating multiple task into a single group. 
- Forward exceptions to OnException directly to avoid delegate allocations. 
- Because we know the max size of a chunk, I've Introduced a reusable StringBuilder to the DatadogHttpClient and LogFormatter so batches don't reallocate. 
- Add a lightweight semaphore to ensure only one batch of events is in-flight at any given time. (needed to allow for reusable builders)
- Adds a flowing cancellation token that will ensure resources get released when the sink is disposed, or if a client breaks.  
- Adds a delay to the sink dispose method to ensure pending batches get written.  
- Constructs chunks used by the HttpClient inline.
- Other minor fixes. 

Tested and haven't seen any issues. We run our .NET code in environments with very little memory (1 GB) and these changes help ensure logging isn't creating memory pressure. 