### PR TITLE
Fixes Newtonsoft wrong serialization when default serialize settings is changed

### DIFF
--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
@@ -8,6 +8,8 @@ using System.IO;
 using System.Collections.Generic;
 using Serilog.Events;
 using Serilog.Formatting.Json;
+using Newtonsoft.Json.Converters;
+using static Serilog.Sinks.Datadog.Logs.Sinks.Datadog.OriginalCaseNamingResolver;
 #if NET5_0_OR_GREATER
 using System.Text.Json;
 using System.Text.Json.Serialization;
@@ -39,13 +41,30 @@ namespace Serilog.Sinks.Datadog.Logs
         /// <summary>
         /// Settings to drop null values.
         /// </summary>
-        private static readonly JsonSerializerOptions settings = new JsonSerializerOptions { WriteIndented = false, DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping};
+        private static readonly JsonSerializerOptions settings = new JsonSerializerOptions 
+        {
+            WriteIndented = false, 
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull, 
+            Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+        };
 #else
 
         /// <summary>
         /// Settings to drop null values.
         /// </summary>
-        private static readonly JsonSerializerSettings settings = new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore, Formatting = Newtonsoft.Json.Formatting.None };
+        private static readonly JsonSerializerSettings settings = new JsonSerializerSettings 
+        {
+            ContractResolver = new OriginalCasePropertyNamesContractResolver(),
+            NullValueHandling = NullValueHandling.Ignore, 
+            Formatting = Newtonsoft.Json.Formatting.None,
+            Converters = new List<JsonConverter>
+            {
+                new IsoDateTimeConverter
+                {
+                    DateTimeFormat = "yyyy'-'MM'-'dd'T'HH':'mm':'ss.ffffffzzz"
+                }
+            }
+        };
 #endif
 
         public LogFormatter(string source, string service, string host, string[] tags)

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/OriginalCaseContractResolver.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/OriginalCaseContractResolver.cs
@@ -1,0 +1,30 @@
+﻿using Newtonsoft.Json.Serialization;
+
+namespace Serilog.Sinks.Datadog.Logs.Sinks.Datadog
+{
+    public class OriginalCaseNamingResolver : NamingStrategy
+    {
+        public OriginalCaseNamingResolver()
+        {
+            this.ProcessDictionaryKeys = true;
+            this.OverrideSpecifiedNames = true;
+        }
+
+        protected override string ResolvePropertyName(string name)
+        {
+            return name;
+        }
+
+        public class OriginalCasePropertyNamesContractResolver : DefaultContractResolver
+        {
+            public OriginalCasePropertyNamesContractResolver()
+            {
+                this.NamingStrategy = new OriginalCaseNamingResolver
+                {
+                    ProcessDictionaryKeys = true,
+                    OverrideSpecifiedNames = true
+                };
+            }
+        }
+    }
+}


### PR DESCRIPTION
When we have a default configuration like:

```
JsonConvert.DefaultSettings = () => new JsonSerializerSettings(...);
```

It can change sink behaviour.

In my tests, changing ContractResolver (to snakecase for example), it changes root properties do default contract resolver instead keep original value.

To fix it, I create OriginalCaseNamingResolver to keep original property name instead of default configuration.

I add a IsoDateTimeConverter too, to fix the same behavior (when default exists, timestamp is changed to another time)

--

Temporarily, I add a copy of project with this changes in my project until my PR is merged

Thanks!

