### PR TITLE
Can replace/extend default LogFormatter on configuration

### DIFF
--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -37,6 +37,7 @@ namespace Serilog
         /// <param name="exceptionHandler">This function is called when an exception occurs when using 
         /// DatadogConfiguration.UseTCP=false (the default configuration)</param>
         /// <param name="detectTCPDisconnection">Detect when the TCP connection is lost and recreate a new connection.</param>
+        /// <param name="logFormatter">The <see cref="ILogFormatter"/> implementation to use for events</param>
         /// <returns>Logger configuration</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration DatadogLogs(
@@ -54,7 +55,7 @@ namespace Serilog
             int? queueLimit = null,
             Action<Exception> exceptionHandler = null,
             bool detectTCPDisconnection = false, IDatadogClient client = null,
-            LogFormatter logFormatter = null)
+            ILogFormatter logFormatter = null)
         {
             if (loggerConfiguration == null)
             {

--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -53,7 +53,8 @@ namespace Serilog
             TimeSpan? batchPeriod = null,
             int? queueLimit = null,
             Action<Exception> exceptionHandler = null,
-            bool detectTCPDisconnection = false, IDatadogClient client = null)
+            bool detectTCPDisconnection = false, IDatadogClient client = null,
+            LogFormatter logFormatter = null)
         {
             if (loggerConfiguration == null)
             {
@@ -65,7 +66,7 @@ namespace Serilog
             }
 
             var config = ApplyMicrosoftExtensionsConfiguration.ConfigureDatadogConfiguration(configuration, configurationSection);
-            var sink = DatadogSink.Create(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, queueLimit, exceptionHandler, detectTCPDisconnection, client);
+            var sink = DatadogSink.Create(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, queueLimit, exceptionHandler, detectTCPDisconnection, client, logFormatter);
 
             return loggerConfiguration.Sink(sink, logLevel);
         }

--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/System.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/System.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -35,6 +35,7 @@ namespace Serilog
         /// <param name="exceptionHandler">This function is called when an exception occurs when using 
         /// DatadogConfiguration.UseTCP=false (the default configuration)</param>
         /// <param name="detectTCPDisconnection">Detect when the TCP connection is lost and recreate a new connection.</param>
+        /// <param name="logFormatter">The <see cref="ILogFormatter"/> implementation to use for events</param>
         /// <returns>Logger configuration</returns>
         /// <exception cref="ArgumentNullException">A required parameter is null.</exception>
         public static LoggerConfiguration DatadogLogs(
@@ -51,7 +52,7 @@ namespace Serilog
             int? queueLimit = null,
             Action<Exception> exceptionHandler = null,
             bool detectTCPDisconnection = false,
-            LogFormatter logFormatter = null)
+            ILogFormatter logFormatter = null)
         {
             if (loggerConfiguration == null)
             {

--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/System.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/System.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -50,7 +50,8 @@ namespace Serilog
             TimeSpan? batchPeriod = null,
             int? queueLimit = null,
             Action<Exception> exceptionHandler = null,
-            bool detectTCPDisconnection = false)
+            bool detectTCPDisconnection = false,
+            LogFormatter logFormatter = null)
         {
             if (loggerConfiguration == null)
             {
@@ -62,7 +63,7 @@ namespace Serilog
             }
 
             configuration = (configuration != null) ? configuration : new DatadogConfiguration();
-            var sink = DatadogSink.Create(apiKey, source, service, host, tags, configuration, batchSizeLimit, batchPeriod, queueLimit, exceptionHandler, detectTCPDisconnection);
+            var sink = DatadogSink.Create(apiKey, source, service, host, tags, configuration, batchSizeLimit, batchPeriod, queueLimit, exceptionHandler, detectTCPDisconnection, logFormatter: logFormatter);
 
             return loggerConfiguration.Sink(sink, logLevel);
         }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
@@ -23,7 +23,7 @@ namespace Serilog.Sinks.Datadog.Logs
 
         private readonly DatadogConfiguration _config;
         private readonly string _url;
-        private readonly LogFormatter _formatter;
+        private readonly ILogFormatter _formatter;
         private readonly HttpClient _client;
 
         /// <summary>
@@ -36,7 +36,7 @@ namespace Serilog.Sinks.Datadog.Logs
         /// </summary>
         private const int MaxBackoff = 30;
 
-        public DatadogHttpClient(DatadogConfiguration config, LogFormatter formatter, string apiKey)
+        public DatadogHttpClient(DatadogConfiguration config, ILogFormatter formatter, string apiKey)
         {
             _config = config;
             _client = new HttpClient();

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -31,7 +31,7 @@ namespace Serilog.Sinks.Datadog.Logs
         /// </summary>
         private const int DefaultBatchSizeLimit = 50;
 
-        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, Action<Exception> exceptionHandler = null, bool detectTCPDisconnection = false, IDatadogClient client = null, LogFormatter logFormatter = null)
+        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, Action<Exception> exceptionHandler = null, bool detectTCPDisconnection = false, IDatadogClient client = null, ILogFormatter logFormatter = null)
             : base(batchSizeLimit ?? DefaultBatchSizeLimit, batchPeriod ?? DefaultBatchPeriod)
         {
             logFormatter = logFormatter ?? new LogFormatter(source, service, host, tags);
@@ -39,7 +39,7 @@ namespace Serilog.Sinks.Datadog.Logs
             _exceptionHandler = exceptionHandler;
         }
 
-        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int queueLimit, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, Action<Exception> exceptionHandler = null, bool detectTCPDisconnection = false, IDatadogClient client = null, LogFormatter logFormatter = null)
+        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int queueLimit, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, Action<Exception> exceptionHandler = null, bool detectTCPDisconnection = false, IDatadogClient client = null, ILogFormatter logFormatter = null)
             : base(batchSizeLimit ?? DefaultBatchSizeLimit, batchPeriod ?? DefaultBatchPeriod, queueLimit)
         {
             logFormatter = logFormatter ?? new LogFormatter(source, service, host, tags);
@@ -59,7 +59,7 @@ namespace Serilog.Sinks.Datadog.Logs
             int? queueLimit = null,
             Action<Exception> exceptionHandler = null,
             bool detectTCPDisconnection = false, IDatadogClient client = null,
-            LogFormatter logFormatter = null)
+            ILogFormatter logFormatter = null)
         {
             if (queueLimit.HasValue)
                 return new DatadogSink(apiKey, source, service, host, tags, config, queueLimit.Value, batchSizeLimit, batchPeriod, exceptionHandler, detectTCPDisconnection, client, logFormatter);
@@ -100,7 +100,7 @@ namespace Serilog.Sinks.Datadog.Logs
             base.Dispose(disposing);
         }
 
-        private static IDatadogClient CreateDatadogClient(string apiKey, LogFormatter logFormatter, DatadogConfiguration configuration, bool detectTCPDisconnection)
+        private static IDatadogClient CreateDatadogClient(string apiKey, ILogFormatter logFormatter, DatadogConfiguration configuration, bool detectTCPDisconnection)
         {
             if (configuration.UseTCP)
             {

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -58,12 +58,13 @@ namespace Serilog.Sinks.Datadog.Logs
             TimeSpan? batchPeriod = null,
             int? queueLimit = null,
             Action<Exception> exceptionHandler = null,
-            bool detectTCPDisconnection = false, IDatadogClient client = null)
+            bool detectTCPDisconnection = false, IDatadogClient client = null,
+            LogFormatter logFormatter = null)
         {
             if (queueLimit.HasValue)
-                return new DatadogSink(apiKey, source, service, host, tags, config, queueLimit.Value, batchSizeLimit, batchPeriod, exceptionHandler, detectTCPDisconnection, client);
+                return new DatadogSink(apiKey, source, service, host, tags, config, queueLimit.Value, batchSizeLimit, batchPeriod, exceptionHandler, detectTCPDisconnection, client, logFormatter);
 
-            return new DatadogSink(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, exceptionHandler, detectTCPDisconnection, client);
+            return new DatadogSink(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, exceptionHandler, detectTCPDisconnection, client, logFormatter);
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -31,31 +31,33 @@ namespace Serilog.Sinks.Datadog.Logs
         /// </summary>
         private const int DefaultBatchSizeLimit = 50;
 
-        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, Action<Exception> exceptionHandler = null, bool detectTCPDisconnection = false, IDatadogClient client = null)
+        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, Action<Exception> exceptionHandler = null, bool detectTCPDisconnection = false, IDatadogClient client = null, LogFormatter logFormatter = null)
             : base(batchSizeLimit ?? DefaultBatchSizeLimit, batchPeriod ?? DefaultBatchPeriod)
         {
-            _client = client ?? CreateDatadogClient(apiKey, source, service, host, tags, config, detectTCPDisconnection);
+            logFormatter = logFormatter ?? new LogFormatter(source, service, host, tags);
+            _client = client ?? CreateDatadogClient(apiKey, logFormatter, config, detectTCPDisconnection);
             _exceptionHandler = exceptionHandler;
         }
 
-        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int queueLimit, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, Action<Exception> exceptionHandler = null, bool detectTCPDisconnection = false, IDatadogClient client = null)
+        public DatadogSink(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration config, int queueLimit, int? batchSizeLimit = null, TimeSpan? batchPeriod = null, Action<Exception> exceptionHandler = null, bool detectTCPDisconnection = false, IDatadogClient client = null, LogFormatter logFormatter = null)
             : base(batchSizeLimit ?? DefaultBatchSizeLimit, batchPeriod ?? DefaultBatchPeriod, queueLimit)
         {
-            _client = client ?? CreateDatadogClient(apiKey, source, service, host, tags, config, detectTCPDisconnection);
+            logFormatter = logFormatter ?? new LogFormatter(source, service, host, tags);
+            _client = client ?? CreateDatadogClient(apiKey, logFormatter, config, detectTCPDisconnection);
             _exceptionHandler = exceptionHandler;
         }
 
         public static DatadogSink Create(
-            string apiKey, 
-            string source, 
-            string service, 
-            string host, 
-            string[] tags, 
-            DatadogConfiguration config, 
-            int? batchSizeLimit = null, 
-            TimeSpan? batchPeriod = null, 
-            int? queueLimit = null, 
-            Action<Exception> exceptionHandler = null, 
+            string apiKey,
+            string source,
+            string service,
+            string host,
+            string[] tags,
+            DatadogConfiguration config,
+            int? batchSizeLimit = null,
+            TimeSpan? batchPeriod = null,
+            int? queueLimit = null,
+            Action<Exception> exceptionHandler = null,
             bool detectTCPDisconnection = false, IDatadogClient client = null)
         {
             if (queueLimit.HasValue)
@@ -97,9 +99,8 @@ namespace Serilog.Sinks.Datadog.Logs
             base.Dispose(disposing);
         }
 
-        private static IDatadogClient CreateDatadogClient(string apiKey, string source, string service, string host, string[] tags, DatadogConfiguration configuration, bool detectTCPDisconnection)
+        private static IDatadogClient CreateDatadogClient(string apiKey, LogFormatter logFormatter, DatadogConfiguration configuration, bool detectTCPDisconnection)
         {
-            var logFormatter = new LogFormatter(source, service, host, tags);
             if (configuration.UseTCP)
             {
                 return new DatadogTcpClient(configuration, logFormatter, apiKey, detectTCPDisconnection);

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogTcpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogTcpClient.cs
@@ -24,7 +24,7 @@ namespace Serilog.Sinks.Datadog.Logs
     public class DatadogTcpClient : IDatadogClient
     {
         private readonly DatadogConfiguration _config;
-        private readonly LogFormatter _formatter;
+        private readonly ILogFormatter _formatter;
         private readonly string _apiKey;
         private readonly bool _detectTCPDisconnection;
         private TcpClient _client;
@@ -56,7 +56,7 @@ namespace Serilog.Sinks.Datadog.Logs
         /// </summary>
         private static readonly UTF8Encoding UTF8 = new UTF8Encoding();
 
-        public DatadogTcpClient(DatadogConfiguration config, LogFormatter formatter, string apiKey, bool detectTCPDisconnection)
+        public DatadogTcpClient(DatadogConfiguration config, ILogFormatter formatter, string apiKey, bool detectTCPDisconnection)
         {
             _config = config;
             _formatter = formatter;

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/ILogFormatter.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/ILogFormatter.cs
@@ -1,0 +1,14 @@
+﻿// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2019 Datadog, Inc.
+
+using Serilog.Events;
+
+namespace Serilog.Sinks.Datadog.Logs
+{
+    public interface ILogFormatter
+    {
+        string FormatMessage(LogEvent logEvent);
+    }
+}

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
@@ -85,12 +85,19 @@ namespace Serilog.Sinks.Datadog.Logs
             // displayed on the Log Explorer
             RenameKey(logEventAsDict, "RenderedMessage", "message");
             RenameKey(logEventAsDict, "Level", "level");
+
+            TransformPayload(logEventAsDict);
+
             // Convert back the dict to a JSON string
 #if NET5_0_OR_GREATER
-    return JsonSerializer.Serialize(logEventAsDict, settings);
+            return JsonSerializer.Serialize(logEventAsDict, settings);
 #else
             return JsonConvert.SerializeObject(logEventAsDict, settings);
 #endif
+        }
+
+        protected virtual void TransformPayload(Dictionary<string, object> payload)
+        {
         }
 
         /// <summary>

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/LogFormatter.cs
@@ -18,7 +18,7 @@ using Newtonsoft.Json;
 
 namespace Serilog.Sinks.Datadog.Logs
 {
-    public class LogFormatter
+    public class LogFormatter : ILogFormatter
     {
         private readonly string _source;
         private readonly string _service;

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/FormatterTests.cs
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/FormatterTests.cs
@@ -36,5 +36,50 @@ namespace Serilog.Sinks.Datadog.Logs.Tests
                 }, elapsedMs));
             }
         }
+
+        public class ExtendedFormatter : LogFormatter
+        {
+            public ExtendedFormatter(string source, string service, string host, string[] tags)
+                : base(source, service, host, tags)
+            {
+            }
+
+            protected override void TransformPayload(Dictionary<string, object> payload)
+            {
+                payload["ddtags"] = new[] { "newtags" };
+            }
+        }
+
+        [Test]
+        public void CanExtendFormatter()
+        {
+#if NET5_0_OR_GREATER
+            var ver = Environment.Version.ToString();
+#else
+            var ver = AppDomain.CurrentDomain.SetupInformation.TargetFrameworkName;
+#endif
+            const string apiKey = "NOT_AN_API_KEY";
+            var config = new DatadogConfiguration();
+            var logFormatter = new ExtendedFormatter(ver, "TEST", "localhost", new[] { "the", "coolest", "test" });
+            var noop = new NoopClient(apiKey, logFormatter);
+            using (var log = new LoggerConfiguration().WriteTo.DatadogLogs(apiKey, configuration: config, client: noop).CreateLogger())
+            {
+                var positions = new dynamic[]
+                {
+                    new { Latitude = byte.MinValue, Longitude = byte.MaxValue },
+                    new { Latitude = short.MinValue, Longitude = short.MaxValue },
+                    new { Latitude = int.MinValue, Longitude = int.MaxValue },
+                    new { Latitude = long.MinValue, Longitude = long.MaxValue }
+                };
+                const int elapsedMs = 34;
+                Assert.DoesNotThrow(() => log.Information("Processed {@Positions} in {Elapsed:000} ms.", new Dictionary<string, object>
+                {
+                    { "positions", positions },
+                    { "creator", "ACME" }
+                }, elapsedMs));
+            }
+
+            Assert.IsTrue(noop.LastLog.Contains("\"ddtags\":[\"newtags\"]"));
+        }
     }
 }

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/NoopClient.cs
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/NoopClient.cs
@@ -13,11 +13,11 @@ namespace Serilog.Sinks.Datadog.Logs.Tests
     public class NoopClient : IDatadogClient
     {
         private readonly string _apiKey;
-        private readonly LogFormatter _formatter;
+        private readonly ILogFormatter _formatter;
 
         public string LastLog { get; private set; }
 
-        public NoopClient(string apiKey, LogFormatter formatter)
+        public NoopClient(string apiKey, ILogFormatter formatter)
         {
             _apiKey = apiKey;
             _formatter = formatter;

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/NoopClient.cs
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/NoopClient.cs
@@ -15,6 +15,8 @@ namespace Serilog.Sinks.Datadog.Logs.Tests
         private readonly string _apiKey;
         private readonly LogFormatter _formatter;
 
+        public string LastLog { get; private set; }
+
         public NoopClient(string apiKey, LogFormatter formatter)
         {
             _apiKey = apiKey;
@@ -39,7 +41,7 @@ namespace Serilog.Sinks.Datadog.Logs.Tests
             });
             var payload = payloadBuilder.ToString();
             Assert.IsNotEmpty(payload);
-
+            LastLog = payload;
 
             return Task.CompletedTask;
         }


### PR DESCRIPTION
Proposal for an extension point on the default LogFormatter (`TransformPayload`) and the ability to pass in any custom ILogFormatter as desired.

Included basic example shows replacing the tags.

An example of a real usage is #43 