### PR TITLE
Fix package name typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ In the platform, the log looks like as the following JSON Object:
 ## Configuration from `appsettings.json`
 
 Since 0.2.0, you can configure the Datadog sink by using an `appsettings.json` file with
-the [Serilog.Setting.Configuration](https://github.com/serilog/serilog-settings-configuration) package.
+the [Serilog.Settings.Configuration](https://github.com/serilog/serilog-settings-configuration) package.
 
 In the `"Serilog.WriteTo"` array, add an entry for `DatadogLogs`. An example is shown below:
 


### PR DESCRIPTION
👋 

I was confused when I copy pasted the package name in Nuget and got no results.

Package name in the documentation is missing an `s`.

https://www.nuget.org/packages/Serilog.Settings.Configuration 