### PR TITLE
Set default Port property to 443

### DIFF
--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogConfiguration.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogConfiguration.cs
@@ -33,7 +33,7 @@ namespace Serilog.Sinks.Datadog.Logs
         /// <summary>
         /// Port of the server to send log events to.
         /// </summary>
-        public int Port { get; set;  }
+        public int Port { get; set;  } = 443;
 
         /// <summary>
         /// Use SSL or plain text.


### PR DESCRIPTION
Prior to this change, if you spin up a new instance of DatadogConfiguration with the default values, no logs will be sent to datadog as default(int) is 0.