### PR TITLE
Bump dependency on Serilog.Sinks.PeriodicBatching to 3.1.0

### DIFF
--- a/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
+++ b/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
@@ -18,7 +18,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.0.0" />
+    <PackageReference Include="Serilog.Sinks.PeriodicBatching" Version="3.1.0" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <Compile Remove="Configuration\Extensions\Microsoft.Extensions.Configuration\**\*.*" />
     <Compile Remove="Configuration\Extensions\System.Configuration\**\*.*" />


### PR DESCRIPTION
Closes: https://github.com/DataDog/serilog-sinks-datadog-logs/issues/97

Signed-off-by: Jesse Szwedko <jesse.szwedko@datadoghq.com>
