### PR TITLE
Disable keep-alive in HttpClient (backport `dd-trace-dotnet` 5810)

### DIFF
--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
@@ -34,6 +34,7 @@ namespace Serilog.Sinks.Datadog.Logs
             _url = url;
             _renderer = renderer;
             _client = client;
+            _client.DefaultRequestHeaders.ConnectionClose = true;
             _maxRetries = maxRetries;
         }
 


### PR DESCRIPTION
This is a backport of the following PR from `dd-trace-dotnet`: https://github.com/DataDog/dd-trace-dotnet/pull/5810

It appears that with .NET 6 there was a change in behavior for HttpClient and it can cause the following error show up:

```
System.Net.Http.HttpIOException: The response ended prematurely. (ResponseEnded)
```

There is a pending escalation that appears to be using this NuGet package and getting this error - which we initially thought was coming from `dd-trace-dotnet`.

Note: I didn't have push access here so had to fork and then PR.