### PR TITLE
http: do not overflow the 5MB limit when adding large messages to the builder

### DIFF
--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
@@ -55,7 +55,7 @@ namespace Serilog.Sinks.Datadog.Logs
                 var payloads = _renderer.RenderDatadogEvents(logEvent);
                 foreach (var payload in payloads)
                 {
-                    if (builder.Size()+payload.Length >= _maxPayloadSize || builder.Count() >= _maxMessageCount)
+                    if (builder.Size()+Encoding.UTF8.GetByteCount(payload) >= _maxPayloadSize || builder.Count() >= _maxMessageCount)
                     {
                         builders.Add(builder);
                         builder = new JsonPayloadBuilder();

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
@@ -55,7 +55,7 @@ namespace Serilog.Sinks.Datadog.Logs
                 var payloads = _renderer.RenderDatadogEvents(logEvent);
                 foreach (var payload in payloads)
                 {
-                    if (builder.Size() >= _maxPayloadSize || builder.Count() >= _maxMessageCount)
+                    if (builder.Size()+payload.Length >= _maxPayloadSize || builder.Count() >= _maxMessageCount)
                     {
                         builders.Add(builder);
                         builder = new JsonPayloadBuilder();


### PR DESCRIPTION
The intake enforces a 5MB limit which is avoided during the serialization by creating enough different payload for each of them to be <5MB.

However, the previous logic was not properly taking into account the size of the currently serialised event. Most of time slipped under the radar because only small events are sent, and the limit is a bit lenient. But when sending big messages, it is possible to trigger this bug.

E.g. with ~800kB messages and `maxMessageSize` configured to `800*1024`, with previous code, it was possible to create payloads bigger than 5MB:

```
payload size: 5620395
payload size: 5582400
payload size: 614
HTTP status code: 413
HTTP status code: 413
HTTP status code: 202
```

with the new logic, they're properly contained in <5MB payloads:

```
paylod size: 4801198
payload size: 4801198
payload size: 1601013
HTTP status code: 202
HTTP status code: 202
HTTP status code: 202
```