### PR TITLE
Fix version incompatibility with PostAsync retry logic

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       matrix:
         dotnet-version:
-          - '5.0.x'
+          - '6.0.x'
 
     steps:
       - uses: actions/checkout@v3

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/Serilog.Sinks.Datadog.Logs.Tests.csproj
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/Serilog.Sinks.Datadog.Logs.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;net472;net5.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Serilog.Sinks.Datadog.Logs.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>


### PR DESCRIPTION
Description and resolution of the problematic PostAsync behavior: https://github.com/dotnet/corefx/pull/19082

This change allows users who are running on impacted versions of .NET Core (~2.0) to successfully retry Post attempts. 