### PR TITLE
Add back logLevel parameter as legacy option for backward compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.6
+
+* Added back `logLevel` parameter as a legacy option for setting minimum log level. When both `logLevel` and `restrictedToMinimumLevel` are set, `restrictedToMinimumLevel` takes precedence.
+
 ## 0.5.5
 
 * Fix version incompatibility with PostAsync retry logic.

--- a/README.md
+++ b/README.md
@@ -164,7 +164,8 @@ If you cannot use Serilog-expressions due to framework compatibility - you can i
 | `host`                     | `string`               | The host name.                                          |
 | `tags`                     | `string[]`             | Custom tags.                                            |
 | `configuration`            | `DatadogConfiguration` | The Datadog logs client configuration.                  |
-| `restrictedToMinimumLevel` | `LogEventLevel`        | The minimum log level for the sink.                     |
+| `restrictedToMinimumLevel` | `LogEventLevel`        | The minimum log level for the sink. Takes precedence over logLevel when both are set. |
+| `logLevel`                | `LogEventLevel`        | Legacy parameter to set the minimum log level for the sink. Used only if restrictedToMinimumLevel is not set. |
 | `batchSizeLimit`           | `int`                  | The maximum number of events to emit in a single batch. |
 | `batchPeriod`              | `TimeSpan`             | The time to wait before emitting a new event batch.     |
 | `queueLimit`               | `int`                  | Maximum number of events to hold in the sink's internal queue, or `null` for an unbounded queue. The default is `10000` |

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ If you cannot use Serilog-expressions due to framework compatibility - you can i
 | `tags`                     | `string[]`             | Custom tags.                                            |
 | `configuration`            | `DatadogConfiguration` | The Datadog logs client configuration.                  |
 | `restrictedToMinimumLevel` | `LogEventLevel`        | The minimum log level for the sink. Takes precedence over logLevel when both are set. |
-| `logLevel`                | `LogEventLevel`        | Legacy parameter to set the minimum log level for the sink. Used only if restrictedToMinimumLevel is not set. |
+| `logLevel`                | `LogEventLevel`        | Legacy parameter to set the minimum log level for the sink. Used only if `restrictedToMinimumLevel` is not set. |
 | `batchSizeLimit`           | `int`                  | The maximum number of events to emit in a single batch. |
 | `batchPeriod`              | `TimeSpan`             | The time to wait before emitting a new event batch.     |
 | `queueLimit`               | `int`                  | Maximum number of events to hold in the sink's internal queue, or `null` for an unbounded queue. The default is `10000` |

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ If you cannot use Serilog-expressions due to framework compatibility - you can i
 | `host`                     | `string`               | The host name.                                          |
 | `tags`                     | `string[]`             | Custom tags.                                            |
 | `configuration`            | `DatadogConfiguration` | The Datadog logs client configuration.                  |
-| `restrictedToMinimumLevel` | `LogEventLevel`        | The minimum log level for the sink. Takes precedence over logLevel when both are set. |
+| `restrictedToMinimumLevel` | `LogEventLevel`        | The minimum log level for the sink. Takes precedence over `logLevel` when both are set. |
 | `logLevel`                | `LogEventLevel`        | Legacy parameter to set the minimum log level for the sink. Used only if `restrictedToMinimumLevel` is not set. |
 | `batchSizeLimit`           | `int`                  | The maximum number of events to emit in a single batch. |
 | `batchPeriod`              | `TimeSpan`             | The time to wait before emitting a new event batch.     |

--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -29,6 +29,7 @@ namespace Serilog
         /// <param name="configuration">The Datadog logs client configuration.</param>
         /// <param name="configurationSection">A config section defining the datadog configuration.</param>
         /// <param name="restrictedToMinimumLevel">The minimum level for this sink</param>
+        /// <param name="logLevel">Legacy parameter to set the minimum level for this sink</param>
         /// <param name="batchSizeLimit">The maximum number of events to emit in a single batch.</param>
         /// <param name="batchPeriod">The time to wait before emitting a new event batch.</param>
         /// <param name="queueLimit">
@@ -53,6 +54,7 @@ namespace Serilog
             DatadogConfiguration configuration = null,
             IConfigurationSection configurationSection = null,
             LogEventLevel restrictedToMinimumLevel = LevelAlias.Minimum,
+            LogEventLevel logLevel = LevelAlias.Minimum,
             int? batchSizeLimit = null,
             TimeSpan? batchPeriod = null,
             int? queueLimit = null,
@@ -74,7 +76,9 @@ namespace Serilog
             var config = ApplyMicrosoftExtensionsConfiguration.ConfigureDatadogConfiguration(configuration, configurationSection);
             var sink = DatadogSink.Create(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, queueLimit, exceptionHandler, detectTCPDisconnection, client, formatter, maxMessageSize);
 
-            return loggerConfiguration.Sink(sink, restrictedToMinimumLevel);
+            // Use restrictedToMinimumLevel if set, otherwise use logLevel
+            var effectiveLevel = restrictedToMinimumLevel != LevelAlias.Minimum ? restrictedToMinimumLevel : logLevel;
+            return loggerConfiguration.Sink(sink, effectiveLevel);
         }
     }
 }


### PR DESCRIPTION
## Motivation
We previously renamed the `logLevel` parameter to `restrictedToMinimumLevel` to align with Serilog's naming conventions. However, this change might affect users who are still using the old `logLevel` parameter in their existing configurations. To ensure backward compatibility and provide a smoother transition path for our users, we want to support both parameter names.

## Description
This PR:
- Adds back the `logLevel` parameter as a legacy option for setting minimum log level
- Makes `restrictedToMinimumLevel` the primary parameter that takes precedence when both are set
- Updates documentation to clearly indicate the relationship between these parameters
- Maintains backward compatibility while encouraging use of the newer `restrictedToMinimumLevel` parameter

### Documentation Updates
- Added clear descriptions in README.md for both parameters
- Updated CHANGELOG.md to reflect the changes
