### PR TITLE
Expose JsonValueFormatter

### DIFF
--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -9,6 +9,7 @@ using Serilog.Events;
 using Serilog.Formatting;
 using Serilog.Sinks.Datadog.Logs;
 using System;
+using Serilog.Formatting.Json;
 
 namespace Serilog
 {
@@ -62,7 +63,8 @@ namespace Serilog
             bool detectTCPDisconnection = false, 
             IDatadogClient client = null,
             ITextFormatter formatter = null,
-            int? maxMessageSize = null)
+            int? maxMessageSize = null,
+            JsonValueFormatter jsonValueFormatter = null)
         {
             if (loggerConfiguration == null)
             {
@@ -74,7 +76,7 @@ namespace Serilog
             }
 
             var config = ApplyMicrosoftExtensionsConfiguration.ConfigureDatadogConfiguration(configuration, configurationSection);
-            var sink = DatadogSink.Create(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, queueLimit, exceptionHandler, detectTCPDisconnection, client, formatter, maxMessageSize);
+            var sink = DatadogSink.Create(apiKey, source, service, host, tags, config, batchSizeLimit, batchPeriod, queueLimit, exceptionHandler, detectTCPDisconnection, client, formatter, maxMessageSize, jsonValueFormatter);
 
             // Use restrictedToMinimumLevel if set, otherwise use logLevel
             var effectiveLevel = restrictedToMinimumLevel != LevelAlias.Minimum ? restrictedToMinimumLevel : logLevel;

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogJsonFormatter.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogJsonFormatter.cs
@@ -14,8 +14,13 @@ namespace Serilog.Sinks.Datadog.Logs
 {
     public class DatadogJsonFormatter : ITextFormatter
     {
-
-        readonly JsonValueFormatter _valueFormatter = new JsonValueFormatter();
+        private readonly JsonValueFormatter _valueFormatter;
+        
+        public DatadogJsonFormatter(JsonValueFormatter jsonValueFormatter = null)
+        {
+            _valueFormatter = jsonValueFormatter ?? new JsonValueFormatter();
+        }
+        
         public void Format(LogEvent logEvent, TextWriter output)
         {
             // Largely based on https://github.com/serilog/serilog-formatting-compact/blob/dev/src/Serilog.Formatting.Compact/Formatting/Compact/RenderedCompactJsonFormatter.cs

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -13,6 +13,7 @@ using Serilog.Core;
 using Serilog.Debugging;
 using Serilog.Events;
 using Serilog.Formatting;
+using Serilog.Formatting.Json;
 using Serilog.Sinks.PeriodicBatching;
 
 [assembly:
@@ -50,9 +51,9 @@ namespace Serilog.Sinks.Datadog.Logs
 
         public DatadogSink(string apiKey, string source, string service, string host, string[] tags,
             DatadogConfiguration config, Action<Exception> exceptionHandler = null, bool detectTCPDisconnection = false,
-            IDatadogClient client = null, ITextFormatter formatter = null, int? maxMessageSize = null)
+            IDatadogClient client = null, ITextFormatter formatter = null, int? maxMessageSize = null, JsonValueFormatter jsonValueFormatter = null)
         {
-            formatter = formatter ?? new DatadogJsonFormatter();
+            formatter = formatter ?? new DatadogJsonFormatter(jsonValueFormatter);
             var enricher = new DatadogLogRenderer(source, service, host, tags, maxMessageSize ?? DefaultMaxMessageSize, formatter);
             _client = client ??
                       CreateDatadogClient(apiKey, enricher, config, detectTCPDisconnection);
@@ -73,7 +74,8 @@ namespace Serilog.Sinks.Datadog.Logs
             bool detectTCPDisconnection = false,
             IDatadogClient client = null,
             ITextFormatter formatter = null,
-            int? maxMessageSize = null)
+            int? maxMessageSize = null,
+            JsonValueFormatter jsonValueFormatter = null)
         {
             var options = new PeriodicBatchingSinkOptions()
             {
@@ -87,7 +89,7 @@ namespace Serilog.Sinks.Datadog.Logs
             }
 
             var sink = new DatadogSink(apiKey, source, service, host, tags, config, exceptionHandler,
-                detectTCPDisconnection, client, formatter, maxMessageSize);
+                detectTCPDisconnection, client, formatter, maxMessageSize, jsonValueFormatter);
 
             return new PeriodicBatchingSink(sink, options);
         }


### PR DESCRIPTION
Expose the `JsonValueFormatter` so that the user can pass one in without having to override the `ITextFormatter`.
I personally need this because I wanna get rid of the type tag.