### PR TITLE
Fix queueLimit behavior to more closely align with the documented expectations and the Serilog standards

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ If you cannot use Serilog-expressions due to framework compatibility - you can i
 | `logLevel`                 | `LogEventLevel`        | Legacy parameter to set the minimum log level for the sink. Used only if `restrictedToMinimumLevel` is not set.              |
 | `batchSizeLimit`           | `int`                  | The maximum number of events to emit in a single batch.                                                                      |
 | `batchPeriod`              | `TimeSpan`             | The time to wait before emitting a new event batch.                                                                          |
-| `queueLimit`               | `int`                  | Maximum number of events to hold in the sink's internal queue, or `null` for an unbounded queue. The default is `10000`      |
+| `queueLimit`               | `int`                  | Maximum number of events to hold in the sink's internal queue, or `null` for an unbounded queue. The default is `100000`      |
 | `exceptionHandler`         | `Action<Exception>`    | This function is called when an exception occurs when using `DatadogConfiguration.UseTCP=false` (the default configuration). |
 | `detectTCPDisconnection`   | `bool`                 | Detect when the TCP connection is lost and recreate a new connection.                                                        |
 | `formatter`                | `ITextFormatter`       | A custom formatter implementation to change the format of the logs                                                           |

--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/Microsoft.Extensions.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -34,7 +34,7 @@ namespace Serilog
         /// <param name="batchPeriod">The time to wait before emitting a new event batch.</param>
         /// <param name="queueLimit">
         /// Maximum number of events to hold in the sink's internal queue, or <c>null</c>
-        /// for an unbounded queue. The default is <c>10000</c>
+        /// for an unbounded queue. The default is <c>100000</c>
         /// </param>
         /// <param name="exceptionHandler">This function is called when an exception occurs when using 
         /// DatadogConfiguration.UseTCP=false (the default configuration)</param>
@@ -57,9 +57,9 @@ namespace Serilog
             LogEventLevel logLevel = LevelAlias.Minimum,
             int? batchSizeLimit = null,
             TimeSpan? batchPeriod = null,
-            int? queueLimit = null,
+            int? queueLimit = DatadogSink.UseDefaultQueueLimit,
             Action<Exception> exceptionHandler = null,
-            bool detectTCPDisconnection = false, 
+            bool detectTCPDisconnection = false,
             IDatadogClient client = null,
             ITextFormatter formatter = null,
             int? maxMessageSize = null)

--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/System.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Extensions/System.Configuration/LoggerConfigurationDatadogLogsExtensions.cs
@@ -31,7 +31,7 @@ namespace Serilog
         /// <param name="batchPeriod">The time to wait before emitting a new event batch.</param>
         /// <param name="queueLimit">
         /// Maximum number of events to hold in the sink's internal queue, or <c>null</c>
-        /// for an unbounded queue. The default is <c>10000</c>
+        /// for an unbounded queue. The default is <c>100000</c>
         /// </param>
         /// <param name="exceptionHandler">This function is called when an exception occurs when using 
         /// DatadogConfiguration.UseTCP=false (the default configuration)</param>
@@ -51,7 +51,7 @@ namespace Serilog
             LogEventLevel logLevel = LevelAlias.Minimum,
             int? batchSizeLimit = null,
             TimeSpan? batchPeriod = null,
-            int? queueLimit = null,
+            int? queueLimit = DatadogSink.UseDefaultQueueLimit,
             Action<Exception> exceptionHandler = null,
             bool detectTCPDisconnection = false,
             ITextFormatter formatter = null,

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpClient.cs
@@ -55,7 +55,7 @@ namespace Serilog.Sinks.Datadog.Logs
                 var payloads = _renderer.RenderDatadogEvents(logEvent);
                 foreach (var payload in payloads)
                 {
-                    if (builder.Size()+Encoding.UTF8.GetByteCount(payload) >= _maxPayloadSize || builder.Count() >= _maxMessageCount)
+                    if (builder.Size() + Encoding.UTF8.GetByteCount(payload) >= _maxPayloadSize || builder.Count() >= _maxMessageCount)
                     {
                         builders.Add(builder);
                         builder = new JsonPayloadBuilder();
@@ -90,7 +90,7 @@ namespace Serilog.Sinks.Datadog.Logs
                     // To guarantee portability, recreate the StringContent every retry.
                     var result = await _client.PostAsync(_url, new StringContent(payload, Encoding.UTF8, _content));
                     lastResult = result;
-                    
+
                     if (result == null) { continue; }
                     if ((int)result.StatusCode >= 500) { continue; }
                     if ((int)result.StatusCode == 429) { continue; }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -47,6 +47,11 @@ namespace Serilog.Sinks.Datadog.Logs
         /// </summary>
         private const int DefaultMaxMessageSize = 256 * 1000;
 
+        /// <summary>
+        /// A special queue limit setting indicating that the default value for PeriodicBatchingSinkOptions' QueueLimit should be used.
+        /// </summary>
+        public const int UseDefaultQueueLimit = -1;
+
 
         public DatadogSink(string apiKey, string source, string service, string host, string[] tags,
             DatadogConfiguration config, Action<Exception> exceptionHandler = null, bool detectTCPDisconnection = false,
@@ -68,7 +73,7 @@ namespace Serilog.Sinks.Datadog.Logs
             DatadogConfiguration config,
             int? batchSizeLimit = null,
             TimeSpan? batchPeriod = null,
-            int? queueLimit = null,
+            int? queueLimit = UseDefaultQueueLimit,
             Action<Exception> exceptionHandler = null,
             bool detectTCPDisconnection = false,
             IDatadogClient client = null,
@@ -81,9 +86,9 @@ namespace Serilog.Sinks.Datadog.Logs
                 Period = batchPeriod ?? DefaultBatchPeriod,
             };
 
-            if (queueLimit.HasValue)
+            if (!queueLimit.HasValue || queueLimit.Value != UseDefaultQueueLimit)
             {
-                options.QueueLimit = queueLimit.Value;
+                options.QueueLimit = queueLimit;
             }
 
             var sink = new DatadogSink(apiKey, source, service, host, tags, config, exceptionHandler,

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/Exceptions/CannotSendLogEventException.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/Exceptions/CannotSendLogEventException.cs
@@ -17,7 +17,7 @@ namespace Serilog.Sinks.Datadog.Logs
         }
 
         public CannotSendLogEventException(string payload, IEnumerable<LogEvent> logEvents, System.Exception ex)
-            : base($"Could not send payload to Datadog: {ex.Message} - {payload}.", logEvents)
+            : base($"Could not send payload to Datadog: {ex.Message}{(ex.InnerException != null ? $" Inner exception: {ex.InnerException.Message}" : "")} - {payload}.", logEvents)
         {
         }
 


### PR DESCRIPTION
Two issues with queueLimit usage were identified. 

1. A null queueLimit is intended to denote an unbounded queue in Serilog's specifications. However, the DatadogSink uses the null value as a default argument, translating it to a real value of 100,000. This PR creates a distinct default value and allows an explicit null to correctly designate unbounded size.

2. The default queueLimit value is 100,000 rather than 10,000 as our documentation suggests. This stems from an initial documentation-only error within Serilog itself that was resolved some years ago; the default value is and always has been 100,000 for both codebases.