### PR TITLE
[ AGNTLOG-439 ] fix devcontainer gnupg version issue

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get update \
     && apt-get install -y --no-install-recommends \
     apt-transport-https \
     dirmngr \
-    gnupg=2.2.40-1.1 \
     ca-certificates \
     && apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF \
     && echo "deb https://download.mono-project.com/repo/debian stable-buster main" | tee /etc/apt/sources.list.d/mono-official-stable.list \

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "Run Net6.0",
+            "name": "Run Net6.0 TestApp",
             "type": "coreclr",
             "request": "launch",
             "preLaunchTask": "build-net6.0",
@@ -16,7 +16,7 @@
             "stopAtEntry": false
         },
         {
-            "name": "Run Net461 (Mono)",
+            "name": "Run Net461 (Mono) TestApp",
             "type": "mono",
             "request": "launch",
             "preLaunchTask": "build-net461",
@@ -24,7 +24,6 @@
             "args": [],
             "cwd": "${workspaceFolder}/TestApp",
             "console": "internalConsole",
-            "stopAtEntry": false
         },
         {
             "name": ".NET Core Attach",
@@ -34,10 +33,13 @@
         },
         {
             "name": "Run Tests",
+            "program": "dotnet",
             "type": "coreclr",
             "request": "launch",
-            "preLaunchTask": "test",
-            "console": "internalConsole"
+            "args": [
+                "test"
+            ],
+            "console": "internalConsole",
         }
     ]
 }

--- a/build-package.sh
+++ b/build-package.sh
@@ -6,7 +6,9 @@ set -e
 # Default configuration
 CONFIG="Release"
 SOLUTION="Serilog.Sinks.Datadog.Logs.sln"
-OUTPUT_DIR="./artifacts"
+OUTPUT_DIR="artifacts"
+
+PROJECT_DIR="src/Serilog.Sinks.Datadog.Logs"
 
 # Process arguments
 while [[ $# -gt 0 ]]; do
@@ -28,7 +30,7 @@ while [[ $# -gt 0 ]]; do
       echo "Options:"
       echo "  --config, -c CONFIG     Build configuration (Debug/Release, default: Release)"
       echo "  --solution, -s SOLUTION Solution file to build (default: Serilog.Sinks.Datadog.Logs.sln)"
-      echo "  --output, -o DIR        Output directory for packages (default: ./artifacts)"
+      echo "  --output, -o DIR        Output directory for packages (default: artifacts)"
       echo "  --help, -h              Show this help message"
       exit 0
       ;;
@@ -59,4 +61,4 @@ echo "Creating NuGet package..."
 dotnet msbuild "$SOLUTION" /t:pack /p:Configuration="$CONFIG" /p:PackageOutputPath="$OUTPUT_DIR"
 
 echo "Build completed successfully!"
-echo "Packages are available in: $OUTPUT_DIR"
+echo "Packages are available in: $PROJECT_DIR/$OUTPUT_DIR"


### PR DESCRIPTION
gnupg version 2.2.40-1.1 is no longer recognized as an installable version. Luckily the package in question does not need to be explicitly installed, as we only rely on it as a dependency for other packages.

Additionally modified the build script and launch targets to be slightly more descriptive.