### PR TITLE
Add support for Datadog DD_ environment variables in Serilog sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,40 @@ In the `"Serilog.WriteTo"` array, add an entry for `DatadogLogs`. An example is 
 
 **NOTE:** the `configuration` section is optional so that you may override the defaults. 
 
+## Using Datadog DD_ environment variables
+
+If sink arguments are not provided, the sink can fall back to the standard Datadog environment variables:
+
+- `DD_SOURCE` → `ddsource` (defaults to `csharp` if not set)
+- `DD_SERVICE` → `service`
+- `DD_HOST` → `host` (if not set, falls back to machine name)
+- `DD_TAGS`, `DD_ENV`, `DD_VERSION` → merged into `ddtags`
+
+Notes:
+- `DD_TAGS` may be comma or space-separated. Example: `DD_TAGS="team:payments region:us-east-1"` or `DD_TAGS=a:1,b:2`
+- `DD_ENV` and `DD_VERSION` are appended as `env:<value>` and `version:<value>` respectively
+- An event-level `host` property still overrides the top-level host for that event
+
+Example usage without explicitly passing arguments:
+
+```bash
+export DD_SERVICE="checkout-svc"
+export DD_ENV="prod"
+export DD_VERSION="1.2.3"
+export DD_TAGS="team:payments,region:us-east-1"
+export DD_HOST="web-01"
+```
+
+```csharp
+using (var log = new LoggerConfiguration()
+    // No source/service/host/tags passed; values come from DD_ env vars above
+    .WriteTo.DatadogLogs("<API_KEY>")
+    .CreateLogger())
+{
+    log.Information("Started");
+}
+```
+
 ## Using a custom log formatter
 You can implement a [custom `ITextFormatter` ](https://github.com/serilog/serilog/blob/dev/src/Serilog/Formatting/ITextFormatter.cs)and pass it to the sink to change the format of your logs. This is useful if you want to add/remove/modify fields from the final JSON payload, or emit non-json logs to Datadog. 
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ If sink arguments are not provided, the sink can fall back to the standard Datad
 
 - `DD_SOURCE` → `ddsource` (defaults to `csharp` if not set)
 - `DD_SERVICE` → `service`
-- `DD_HOST` → `host` (if not set, falls back to machine name)
+- `DD_HOST` → `host`
 - `DD_TAGS`, `DD_ENV`, `DD_VERSION` → merged into `ddtags`
 
 Notes:

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogLogRenderer.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogLogRenderer.cs
@@ -171,16 +171,15 @@ namespace Serilog.Sinks.Datadog.Logs
 
         private static string[] MergeWithDatadogEnvTags(string[] originalTags)
         {
-            var result = new List<string>();
-            var seen = new HashSet<string>(StringComparer.Ordinal);
+            var set = new HashSet<string>(StringComparer.Ordinal);
             if (originalTags != null)
             {
                 foreach (var t in originalTags)
                 {
                     var trimmed = (t ?? "").Trim();
-                    if (!string.IsNullOrEmpty(trimmed) && seen.Add(trimmed))
+                    if (!string.IsNullOrEmpty(trimmed))
                     {
-                        result.Add(trimmed);
+                        set.Add(trimmed);
                     }
                 }
             }
@@ -192,9 +191,9 @@ namespace Serilog.Sinks.Datadog.Logs
                 foreach (var p in parts)
                 {
                     var trimmed = p.Trim();
-                    if (!string.IsNullOrEmpty(trimmed) && seen.Add(trimmed))
+                    if (!string.IsNullOrEmpty(trimmed))
                     {
-                        result.Add(trimmed);
+                        set.Add(trimmed);
                     }
                 }
             }
@@ -202,24 +201,16 @@ namespace Serilog.Sinks.Datadog.Logs
             var ddEnv = GetEnv("DD_ENV");
             if (!string.IsNullOrWhiteSpace(ddEnv))
             {
-                var envTag = $"env:{ddEnv}";
-                if (seen.Add(envTag))
-                {
-                    result.Add(envTag);
-                }
+                set.Add($"env:{ddEnv}");
             }
 
             var ddVersion = GetEnv("DD_VERSION");
             if (!string.IsNullOrWhiteSpace(ddVersion))
             {
-                var versionTag = $"version:{ddVersion}";
-                if (seen.Add(versionTag))
-                {
-                    result.Add(versionTag);
-                }
+                set.Add($"version:{ddVersion}");
             }
 
-            return result.ToArray();
+            return set.ToArray();
         }
     }
 }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogLogRenderer.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogLogRenderer.cs
@@ -54,37 +54,8 @@ namespace Serilog.Sinks.Datadog.Logs
             _formatter.Format(logEvent, payloadWriter);
             var rawPayload = payloadWriter.ToString();
 
-            // Allow an event-level "host" property to override the configured/default host
-            List<LogEventProperty> propsToUse = _props;
-            if (logEvent.Properties != null && logEvent.Properties.TryGetValue("host", out var hostProperty))
-            {
-                var hostOverride = TryConvertScalarToString(hostProperty);
-                if (!string.IsNullOrWhiteSpace(hostOverride))
-                {
-                    var cloned = new List<LogEventProperty>(_props.Count);
-                    var replaced = false;
-                    foreach (var p in _props)
-                    {
-                        if (string.Equals(p.Name, "host", StringComparison.Ordinal))
-                        {
-                            cloned.Add(new LogEventProperty("host", new ScalarValue(hostOverride)));
-                            replaced = true;
-                        }
-                        else
-                        {
-                            cloned.Add(p);
-                        }
-                    }
-                    if (!replaced)
-                    {
-                        cloned.Add(new LogEventProperty("host", new ScalarValue(hostOverride)));
-                    }
-                    propsToUse = cloned;
-                }
-            }
-
             return TruncateIfNeeded(rawPayload)
-                .Select(x => ToDDPayload(Encoding.UTF8.GetString(x), propsToUse))
+                .Select(x => ToDDPayload(Encoding.UTF8.GetString(x)))
                 .ToArray();
         }
 

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogLogRenderer.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogLogRenderer.cs
@@ -26,7 +26,7 @@ namespace Serilog.Sinks.Datadog.Logs
         {
 
             // Resolve values from environment variables when not provided
-            var resolvedSource = string.IsNullOrWhiteSpace(source) ? (GetEnv("DD_SOURCE") ?? CSHARP) : source;
+			var resolvedSource = source ?? (GetEnv("DD_SOURCE") ?? CSHARP);
             var resolvedService = string.IsNullOrWhiteSpace(service) ? GetEnv("DD_SERVICE") : service;
             var resolvedHost = string.IsNullOrWhiteSpace(host) ? GetEnv("DD_HOST") : host;
             var resolvedTags = MergeWithDatadogEnvTags(tags);
@@ -137,8 +137,8 @@ namespace Serilog.Sinks.Datadog.Logs
 
         private static string GetMachineNameOrNull()
         {
-#if NETSTANDARD1_3
-            // Environment.MachineName is not available on netstandard1.3
+#if NETSTANDARD1_0_OR_GREATER && !NETSTANDARD2_0_OR_GREATER
+			// Environment.MachineName is not available on netstandard1.x
             return GetEnv("COMPUTERNAME") ?? GetEnv("HOSTNAME");
 #else
             try

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogLogRenderer.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogLogRenderer.cs
@@ -31,6 +31,15 @@ namespace Serilog.Sinks.Datadog.Logs
             var resolvedHost = string.IsNullOrWhiteSpace(host) ? GetEnv("DD_HOST") : host;
             var resolvedTags = MergeWithDatadogEnvTags(tags);
 
+            if (string.IsNullOrWhiteSpace(resolvedHost) && resolveHostIfMissing)
+            {
+                var machineName = GetMachineNameOrNull();
+                if (!string.IsNullOrWhiteSpace(machineName))
+                {
+                    resolvedHost = machineName;
+                }
+            }
+
             var props = new List<LogEventProperty> {
                 new LogEventProperty("ddsource", new ScalarValue(resolvedSource)),
             };
@@ -124,6 +133,28 @@ namespace Serilog.Sinks.Datadog.Logs
             ddPayloadWriter.Write("}");
 
             return ddPayloadWriter.ToString();
+        }
+
+        private static string GetMachineNameOrNull()
+        {
+#if NETSTANDARD1_3
+            // Environment.MachineName is not available on netstandard1.3
+            return GetEnv("COMPUTERNAME") ?? GetEnv("HOSTNAME");
+#else
+            try
+            {
+                var name = Environment.MachineName;
+                if (!string.IsNullOrWhiteSpace(name))
+                {
+                    return name;
+                }
+            }
+            catch
+            {
+                // ignore and fallback to env vars
+            }
+            return GetEnv("COMPUTERNAME") ?? GetEnv("HOSTNAME");
+#endif
         }
 
         private static string GetEnv(string name)

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogLogRenderer.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogLogRenderer.cs
@@ -1,7 +1,7 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2019 Datadog, Inc.
+// Copyright 2026 Datadog, Inc.
 
 using System;
 using Serilog.Events;
@@ -28,7 +28,7 @@ namespace Serilog.Sinks.Datadog.Logs
             // Resolve values from environment variables when not provided
             var resolvedSource = string.IsNullOrWhiteSpace(source) ? (GetEnv("DD_SOURCE") ?? CSHARP) : source;
             var resolvedService = string.IsNullOrWhiteSpace(service) ? GetEnv("DD_SERVICE") : service;
-            var resolvedHost = string.IsNullOrWhiteSpace(host) ? (GetEnv("DD_HOST") ?? GetDefaultHostName()) : host;
+            var resolvedHost = string.IsNullOrWhiteSpace(host) ? GetEnv("DD_HOST") : host;
             var resolvedTags = MergeWithDatadogEnvTags(tags);
 
             var props = new List<LogEventProperty> {
@@ -155,18 +155,6 @@ namespace Serilog.Sinks.Datadog.Logs
             return ddPayloadWriter.ToString();
         }
 
-        private static string GetDefaultHostName()
-        {
-#if NETSTANDARD1_0_OR_GREATER && !NETSTANDARD2_0_OR_GREATER
-            // Environment.MachineName is not available on netstandard1.x
-            var fromEnv = Environment.GetEnvironmentVariable("COMPUTERNAME")
-                ?? Environment.GetEnvironmentVariable("HOSTNAME");
-            return string.IsNullOrWhiteSpace(fromEnv) ? null : fromEnv;
-#else
-            return Environment.MachineName;
-#endif
-        }
-
         private static string TryConvertScalarToString(LogEventPropertyValue value)
         {
             if (value is ScalarValue scalar && scalar.Value is string s)
@@ -191,12 +179,13 @@ namespace Serilog.Sinks.Datadog.Logs
         private static string[] MergeWithDatadogEnvTags(string[] originalTags)
         {
             var result = new List<string>();
+            var seen = new HashSet<string>(StringComparer.Ordinal);
             if (originalTags != null)
             {
                 foreach (var t in originalTags)
                 {
                     var trimmed = (t ?? "").Trim();
-                    if (!string.IsNullOrEmpty(trimmed) && !result.Contains(trimmed))
+                    if (!string.IsNullOrEmpty(trimmed) && seen.Add(trimmed))
                     {
                         result.Add(trimmed);
                     }
@@ -210,7 +199,7 @@ namespace Serilog.Sinks.Datadog.Logs
                 foreach (var p in parts)
                 {
                     var trimmed = p.Trim();
-                    if (!string.IsNullOrEmpty(trimmed) && !result.Contains(trimmed))
+                    if (!string.IsNullOrEmpty(trimmed) && seen.Add(trimmed))
                     {
                         result.Add(trimmed);
                     }
@@ -221,7 +210,7 @@ namespace Serilog.Sinks.Datadog.Logs
             if (!string.IsNullOrWhiteSpace(ddEnv))
             {
                 var envTag = $"env:{ddEnv}";
-                if (!result.Contains(envTag))
+                if (seen.Add(envTag))
                 {
                     result.Add(envTag);
                 }
@@ -231,7 +220,7 @@ namespace Serilog.Sinks.Datadog.Logs
             if (!string.IsNullOrWhiteSpace(ddVersion))
             {
                 var versionTag = $"version:{ddVersion}";
-                if (!result.Contains(versionTag))
+                if (seen.Add(versionTag))
                 {
                     result.Add(versionTag);
                 }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogLogRenderer.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogLogRenderer.cs
@@ -34,9 +34,9 @@ namespace Serilog.Sinks.Datadog.Logs
             var props = new List<LogEventProperty> {
                 new LogEventProperty("ddsource", new ScalarValue(resolvedSource)),
             };
-            if (service != null) { props.Add(new LogEventProperty("service", new ScalarValue(service))); }
-            if (host != null) { props.Add(new LogEventProperty("host", new ScalarValue(host))); }
-            if (tags != null) { props.Add(new LogEventProperty("ddtags", new ScalarValue(string.Join(",", tags)))); }
+            if (resolvedService != null) { props.Add(new LogEventProperty("service", new ScalarValue(resolvedService))); }
+            if (resolvedHost != null) { props.Add(new LogEventProperty("host", new ScalarValue(resolvedHost))); }
+            if (resolvedTags != null && resolvedTags.Length > 0) { props.Add(new LogEventProperty("ddtags", new ScalarValue(string.Join(",", resolvedTags)))); }
             _props = props;
             _maxMessageSize = maxMessageSize;
             _formatter = formatter;
@@ -124,6 +124,71 @@ namespace Serilog.Sinks.Datadog.Logs
             ddPayloadWriter.Write("}");
 
             return ddPayloadWriter.ToString();
+        }
+
+        private static string GetEnv(string name)
+        {
+            try
+            {
+                return Environment.GetEnvironmentVariable(name);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string[] MergeWithDatadogEnvTags(string[] originalTags)
+        {
+            var result = new List<string>();
+            var seen = new HashSet<string>(StringComparer.Ordinal);
+            if (originalTags != null)
+            {
+                foreach (var t in originalTags)
+                {
+                    var trimmed = (t ?? "").Trim();
+                    if (!string.IsNullOrEmpty(trimmed) && seen.Add(trimmed))
+                    {
+                        result.Add(trimmed);
+                    }
+                }
+            }
+
+            var ddTags = GetEnv("DD_TAGS");
+            if (!string.IsNullOrWhiteSpace(ddTags))
+            {
+                var parts = ddTags.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (var p in parts)
+                {
+                    var trimmed = p.Trim();
+                    if (!string.IsNullOrEmpty(trimmed) && seen.Add(trimmed))
+                    {
+                        result.Add(trimmed);
+                    }
+                }
+            }
+
+            var ddEnv = GetEnv("DD_ENV");
+            if (!string.IsNullOrWhiteSpace(ddEnv))
+            {
+                var envTag = $"env:{ddEnv}";
+                if (seen.Add(envTag))
+                {
+                    result.Add(envTag);
+                }
+            }
+
+            var ddVersion = GetEnv("DD_VERSION");
+            if (!string.IsNullOrWhiteSpace(ddVersion))
+            {
+                var versionTag = $"version:{ddVersion}";
+                if (seen.Add(versionTag))
+                {
+                    result.Add(versionTag);
+                }
+            }
+
+            return result.ToArray();
         }
     }
 }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogLogRenderer.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogLogRenderer.cs
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019 Datadog, Inc.
 
+using System;
 using Serilog.Events;
 using System.Collections.Generic;
 using System.Text;
@@ -24,12 +25,18 @@ namespace Serilog.Sinks.Datadog.Logs
         public DatadogLogRenderer(string source, string service, string host, string[] tags, int maxMessageSize, ITextFormatter formatter, int? ddPayloadSize = null)
         {
 
+            // Resolve values from environment variables when not provided
+            var resolvedSource = string.IsNullOrWhiteSpace(source) ? (GetEnv("DD_SOURCE") ?? CSHARP) : source;
+            var resolvedService = string.IsNullOrWhiteSpace(service) ? GetEnv("DD_SERVICE") : service;
+            var resolvedHost = string.IsNullOrWhiteSpace(host) ? (GetEnv("DD_HOST") ?? GetDefaultHostName()) : host;
+            var resolvedTags = MergeWithDatadogEnvTags(tags);
+
             var props = new List<LogEventProperty> {
-                new LogEventProperty("ddsource", new ScalarValue(source ?? CSHARP)),
+                new LogEventProperty("ddsource", new ScalarValue(resolvedSource)),
             };
-            if (service != null) { props.Add(new LogEventProperty("service", new ScalarValue(service))); }
-            if (host != null) { props.Add(new LogEventProperty("host", new ScalarValue(host))); }
-            if (tags != null) { props.Add(new LogEventProperty("ddtags", new ScalarValue(string.Join(",", tags)))); }
+            if (resolvedService != null) { props.Add(new LogEventProperty("service", new ScalarValue(resolvedService))); }
+            if (resolvedHost != null) { props.Add(new LogEventProperty("host", new ScalarValue(resolvedHost))); }
+            if (resolvedTags != null && resolvedTags.Length > 0) { props.Add(new LogEventProperty("ddtags", new ScalarValue(string.Join(",", resolvedTags)))); }
             _props = props;
             _maxMessageSize = maxMessageSize;
             _formatter = formatter;
@@ -47,8 +54,37 @@ namespace Serilog.Sinks.Datadog.Logs
             _formatter.Format(logEvent, payloadWriter);
             var rawPayload = payloadWriter.ToString();
 
+            // Allow an event-level "host" property to override the configured/default host
+            List<LogEventProperty> propsToUse = _props;
+            if (logEvent.Properties != null && logEvent.Properties.TryGetValue("host", out var hostProperty))
+            {
+                var hostOverride = TryConvertScalarToString(hostProperty);
+                if (!string.IsNullOrWhiteSpace(hostOverride))
+                {
+                    var cloned = new List<LogEventProperty>(_props.Count);
+                    var replaced = false;
+                    foreach (var p in _props)
+                    {
+                        if (string.Equals(p.Name, "host", StringComparison.Ordinal))
+                        {
+                            cloned.Add(new LogEventProperty("host", new ScalarValue(hostOverride)));
+                            replaced = true;
+                        }
+                        else
+                        {
+                            cloned.Add(p);
+                        }
+                    }
+                    if (!replaced)
+                    {
+                        cloned.Add(new LogEventProperty("host", new ScalarValue(hostOverride)));
+                    }
+                    propsToUse = cloned;
+                }
+            }
+
             return TruncateIfNeeded(rawPayload)
-                .Select(x => ToDDPayload(Encoding.UTF8.GetString(x)))
+                .Select(x => ToDDPayload(Encoding.UTF8.GetString(x), propsToUse))
                 .ToArray();
         }
 
@@ -90,6 +126,11 @@ namespace Serilog.Sinks.Datadog.Logs
 
         internal string ToDDPayload(string rawPayload)
         {
+            return ToDDPayload(rawPayload, _props);
+        }
+
+        internal string ToDDPayload(string rawPayload, IReadOnlyList<LogEventProperty> props)
+        {
             // Render the dd event - a private json structure with the user event in the `message` field and 
             // Datadog specific fields at the root level. The message field can accept any format. By default 
             // Serilog sink will emit json - but the user can change change this format. 
@@ -98,7 +139,7 @@ namespace Serilog.Sinks.Datadog.Logs
             var ddPayloadWriter = new System.IO.StringWriter(ddPayload);
 
             ddPayloadWriter.Write("{");
-            foreach (var prop in _props)
+            foreach (var prop in props)
             {
                 JsonValueFormatter.WriteQuotedJsonString(prop.Name, ddPayloadWriter);
                 ddPayloadWriter.Write(":");
@@ -112,6 +153,91 @@ namespace Serilog.Sinks.Datadog.Logs
             ddPayloadWriter.Write("}");
 
             return ddPayloadWriter.ToString();
+        }
+
+        private static string GetDefaultHostName()
+        {
+#if NETSTANDARD1_0_OR_GREATER && !NETSTANDARD2_0_OR_GREATER
+            // Environment.MachineName is not available on netstandard1.x
+            var fromEnv = Environment.GetEnvironmentVariable("COMPUTERNAME")
+                ?? Environment.GetEnvironmentVariable("HOSTNAME");
+            return string.IsNullOrWhiteSpace(fromEnv) ? null : fromEnv;
+#else
+            return Environment.MachineName;
+#endif
+        }
+
+        private static string TryConvertScalarToString(LogEventPropertyValue value)
+        {
+            if (value is ScalarValue scalar && scalar.Value is string s)
+            {
+                return s;
+            }
+            return null;
+        }
+
+        private static string GetEnv(string name)
+        {
+            try
+            {
+                return Environment.GetEnvironmentVariable(name);
+            }
+            catch
+            {
+                return null;
+            }
+        }
+
+        private static string[] MergeWithDatadogEnvTags(string[] originalTags)
+        {
+            var result = new List<string>();
+            if (originalTags != null)
+            {
+                foreach (var t in originalTags)
+                {
+                    var trimmed = (t ?? "").Trim();
+                    if (!string.IsNullOrEmpty(trimmed) && !result.Contains(trimmed))
+                    {
+                        result.Add(trimmed);
+                    }
+                }
+            }
+
+            var ddTags = GetEnv("DD_TAGS");
+            if (!string.IsNullOrWhiteSpace(ddTags))
+            {
+                var parts = ddTags.Split(new[] { ',', ' ' }, StringSplitOptions.RemoveEmptyEntries);
+                foreach (var p in parts)
+                {
+                    var trimmed = p.Trim();
+                    if (!string.IsNullOrEmpty(trimmed) && !result.Contains(trimmed))
+                    {
+                        result.Add(trimmed);
+                    }
+                }
+            }
+
+            var ddEnv = GetEnv("DD_ENV");
+            if (!string.IsNullOrWhiteSpace(ddEnv))
+            {
+                var envTag = $"env:{ddEnv}";
+                if (!result.Contains(envTag))
+                {
+                    result.Add(envTag);
+                }
+            }
+
+            var ddVersion = GetEnv("DD_VERSION");
+            if (!string.IsNullOrWhiteSpace(ddVersion))
+            {
+                var versionTag = $"version:{ddVersion}";
+                if (!result.Contains(versionTag))
+                {
+                    result.Add(versionTag);
+                }
+            }
+
+            return result.ToArray();
         }
     }
 }

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/EnvFallbackTests.cs
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/EnvFallbackTests.cs
@@ -1,7 +1,9 @@
 using System;
+using System.Linq;
 using NUnit.Framework;
 using Serilog;
 using Serilog.Sinks.Datadog.Logs;
+using System.Text.Json;
 
 namespace Serilog.Sinks.Datadog.Logs.Tests
 {
@@ -90,7 +92,18 @@ namespace Serilog.Sinks.Datadog.Logs.Tests
             }
 
             var payload = noop.SentPayloads[0];
-            StringAssert.Contains("\"ddtags\":\"x:9,a:1,b:2,env:prod,version:1.2.3\"", payload);
+			using (var doc = JsonDocument.Parse(payload))
+			{
+				Assert.IsTrue(doc.RootElement.TryGetProperty("ddtags", out var ddtagsElement), "Payload missing 'ddtags'.");
+				var ddtags = ddtagsElement.GetString();
+				Assert.IsNotNull(ddtags, "'ddtags' must be a string.");
+				var actual = ddtags
+					.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries)
+					.Select(t => t.Trim())
+					.ToArray();
+				var expected = new[] { "x:9", "a:1", "b:2", "env:prod", "version:1.2.3" };
+				CollectionAssert.AreEquivalent(expected, actual, "Tags should be equivalent regardless of order.");
+			}
         }
     }
 }

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/EnvFallbackTests.cs
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/EnvFallbackTests.cs
@@ -1,0 +1,97 @@
+using System;
+using NUnit.Framework;
+using Serilog;
+using Serilog.Sinks.Datadog.Logs;
+
+namespace Serilog.Sinks.Datadog.Logs.Tests
+{
+    [TestFixture]
+    public class EnvFallbackTests
+    {
+        [SetUp]
+        public void ClearDdEnv()
+        {
+            Environment.SetEnvironmentVariable("DD_SERVICE", null);
+            Environment.SetEnvironmentVariable("DD_SOURCE", null);
+            Environment.SetEnvironmentVariable("DD_HOST", null);
+            Environment.SetEnvironmentVariable("DD_TAGS", null);
+            Environment.SetEnvironmentVariable("DD_ENV", null);
+            Environment.SetEnvironmentVariable("DD_VERSION", null);
+        }
+
+        [Test]
+        public void UsesDdServiceWhenServiceUnset()
+        {
+            Environment.SetEnvironmentVariable("DD_SERVICE", "svc-from-env");
+
+            const string apiKey = "NOT_AN_API_KEY";
+            var renderer = new DatadogLogRenderer(null, null, "localhost", null, 256 * 1000, new DatadogJsonFormatter());
+            var noop = new NoopClient(apiKey, renderer);
+
+            using (var log = new LoggerConfiguration().WriteTo.DatadogLogs(apiKey, client: noop).CreateLogger())
+            {
+                log.Information("hello");
+            }
+
+            var payload = noop.SentPayloads[0];
+            StringAssert.Contains("\"service\":\"svc-from-env\"", payload);
+        }
+
+        [Test]
+        public void UsesDdSourceWhenSourceUnset()
+        {
+            Environment.SetEnvironmentVariable("DD_SOURCE", "csharp-env");
+
+            const string apiKey = "NOT_AN_API_KEY";
+            var renderer = new DatadogLogRenderer(null, "svc", "localhost", null, 256 * 1000, new DatadogJsonFormatter());
+            var noop = new NoopClient(apiKey, renderer);
+
+            using (var log = new LoggerConfiguration().WriteTo.DatadogLogs(apiKey, client: noop).CreateLogger())
+            {
+                log.Information("hello");
+            }
+
+            var payload = noop.SentPayloads[0];
+            StringAssert.Contains("\"ddsource\":\"csharp-env\"", payload);
+        }
+
+        [Test]
+        public void UsesDdHostWhenHostUnset()
+        {
+            Environment.SetEnvironmentVariable("DD_HOST", "env-host");
+
+            const string apiKey = "NOT_AN_API_KEY";
+            var renderer = new DatadogLogRenderer("SRC", "SVC", null, null, 256 * 1000, new DatadogJsonFormatter());
+            var noop = new NoopClient(apiKey, renderer);
+
+            using (var log = new LoggerConfiguration().WriteTo.DatadogLogs(apiKey, client: noop).CreateLogger())
+            {
+                log.Information("hello");
+            }
+
+            var payload = noop.SentPayloads[0];
+            StringAssert.Contains("\"host\":\"env-host\"", payload);
+        }
+
+        [Test]
+        public void MergesDdTagsEnvAndVersionIntoDdtags()
+        {
+            Environment.SetEnvironmentVariable("DD_TAGS", "a:1,b:2");
+            Environment.SetEnvironmentVariable("DD_ENV", "prod");
+            Environment.SetEnvironmentVariable("DD_VERSION", "1.2.3");
+
+            const string apiKey = "NOT_AN_API_KEY";
+            var renderer = new DatadogLogRenderer("SRC", "SVC", "HOST", new[] { "x:9" }, 256 * 1000, new DatadogJsonFormatter());
+            var noop = new NoopClient(apiKey, renderer);
+
+            using (var log = new LoggerConfiguration().WriteTo.DatadogLogs(apiKey, client: noop).CreateLogger())
+            {
+                log.Information("hello");
+            }
+
+            var payload = noop.SentPayloads[0];
+            StringAssert.Contains("\"ddtags\":\"x:9,a:1,b:2,env:prod,version:1.2.3\"", payload);
+        }
+    }
+}
+


### PR DESCRIPTION
**Motivation**
Align sink configuration with standard Datadog env-based setups so it’s swappable with DD Agent-style config without code changes.
[AGNTLOG-428](https://datadoghq.atlassian.net/browse/AGNTLOG-428)
[Feature request 132](https://github.com/DataDog/serilog-sinks-datadog-logs/issues/132)

**What’s changing**
Add environment-variable fallbacks when explicit sink args are not provided:

- DD_SOURCE → ddsource (defaults to csharp if neither set)
- DD_SERVICE → service
- DD_HOST → host
- DD_TAGS, DD_ENV, DD_VERSION → merged into ddtags

Update README with usage and examples.

**Precedence**
Explicit sink args (source/service/host/tags) take priority.
If unset, use DD_ env vars.
For tags: Merge DD_TAGS (comma or space-separated), plus env:<DD_ENV> and version:<DD_VERSION>, dedup by exact string.

**Examples**
```
export DD_SERVICE="checkout-svc"
export DD_ENV="prod"
export DD_VERSION="1.2.3"
export DD_TAGS="team:payments,region:us-east-1"
export DD_HOST="web-01"
```
```
using (var log = new LoggerConfiguration()
    .WriteTo.DatadogLogs("<API_KEY>") // no args; reads from DD_ env
    .CreateLogger())
{
    log.Information("Started");
}
```

**Validation**
New tests in tests/Serilog.Sinks.Datadog.Logs.Tests/EnvFallbackTests.cs:

- Uses DD_SERVICE when service unset
- Uses DD_SOURCE when source unset
- Uses DD_HOST when host unset
- Merges DD_TAGS, DD_ENV, DD_VERSION into ddtags

```
cd /Users/gouri.yerra/dev/serilog-sinks-datadog-logs
dotnet test Serilog.Sinks.Datadog.Logs.sln -v minimal --nologo
```

README: “Using Datadog DD_ environment variables” section with mappings, notes, and examples.

[AGNTLOG-428]: https://datadoghq.atlassian.net/browse/AGNTLOG-428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ