### PR TITLE
feat: add proxy support for HTTP log submission (#62)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.2
+
+* Add proxy support for HTTP log submission. Set `DatadogConfiguration.Proxy` (IWebProxy) or `DatadogConfiguration.ProxyUrl` (string) so logs are sent through an HTTP proxy, e.g. to align with [Datadog agent proxy configuration](https://docs.datadoghq.com/agent/proxy/). Resolves [#62](https://github.com/DataDog/serilog-sinks-datadog-logs/issues/62).
+
 ## 0.6.1
 
 * Add `DatadogConfiguration.ResolveHostIfMissing` (and env `DD_LOGS_SINK_RESOLVE_HOST`) to provide a default `host` value when the sink `Host` option is unset. Uses `Environment.MachineName` if available, will fallback to `COMPUTERNAME`/`HOSTNAME` on `netstandard1.x`

--- a/README.md
+++ b/README.md
@@ -21,6 +21,25 @@ You can change the site to EU by using the `url` property and set it to `https:/
 
 You can override the default behavior and use **TCP** forwarding by manually specifing the following properties (url, port, useSSL, useTCP).
 
+To send logs through an HTTP proxy (e.g. to align with [Datadog agent proxy configuration](https://docs.datadoghq.com/agent/proxy/)), set `configuration.Proxy` or `configuration.ProxyUrl`:
+
+```csharp
+// Option 1: Proxy URL string (works with appsettings.json)
+var config = new DatadogConfiguration(proxyUrl: "http://proxy.example.com:8080");
+// Option 2: IWebProxy for full control (credentials, bypass list)
+var config = new DatadogConfiguration();
+config.Proxy = new WebProxy("http://proxy.example.com:8080") { UseDefaultCredentials = false };
+
+using (var log = new LoggerConfiguration()
+    .WriteTo.DatadogLogs("<API_KEY>", configuration: config)
+    .CreateLogger())
+{
+    log.Information("Logs sent via proxy");
+}
+```
+
+**Note:** A third-party package [Serilog.Sinks.Datadog.Logs.WithProxy](https://www.nuget.org/packages/Serilog.Sinks.Datadog.Logs.WithProxy) also adds proxy support (e.g. for older sink versions). Prefer the built-in `Proxy` / `ProxyUrl` above when using a recent release of this sink.
+
 You can also add the following properties (source, service, host, tags) to the Serilog sink.
 
 * Example with a TCP forwarder which add the source, service, host and a list of tags to the logs:
@@ -117,7 +136,8 @@ In the `"Serilog.WriteTo"` array, add an entry for `DatadogLogs`. An example is 
           "url": "intake.logs.datadoghq.com", 
           "port": 10516, 
           "useSSL": true, 
-          "useTCP": true
+          "useTCP": true,
+          "proxyUrl": "http://proxy.example.com:8080"
         }
       }
     }
@@ -197,7 +217,7 @@ If you cannot use Serilog-expressions due to framework compatibility - you can i
 | `service`                  | `string`               | The service name.                                                                                                            |
 | `host`                     | `string`               | The host name.                                                                                                               |
 | `tags`                     | `string[]`             | Custom tags.                                                                                                                 |
-| `configuration`            | `DatadogConfiguration` | The Datadog logs client configuration.                                                                                       |
+| `configuration`            | `DatadogConfiguration` | The Datadog logs client configuration. Use `configuration.Proxy` or `configuration.ProxyUrl` to send logs via an HTTP proxy (see [Datadog agent proxy](https://docs.datadoghq.com/agent/proxy/)). |
 | `restrictedToMinimumLevel` | `LogEventLevel`        | The minimum log level for the sink. Takes precedence over `logLevel` when both are set.                                      |
 | `logLevel`                 | `LogEventLevel`        | Legacy parameter to set the minimum log level for the sink. Used only if `restrictedToMinimumLevel` is not set.              |
 | `batchSizeLimit`           | `int`                  | The maximum number of events to emit in a single batch.                                                                      |

--- a/src/Serilog.Sinks.Datadog.Logs/Configuration/Implementations/Microsoft.Extensions.Configuration/ApplyMicrosoftExtensionsConfiguration.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Configuration/Implementations/Microsoft.Extensions.Configuration/ApplyMicrosoftExtensionsConfiguration.cs
@@ -1,4 +1,4 @@
-﻿// Unless explicitly stated otherwise all files in this repository are licensed
+// Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019 Datadog, Inc.
@@ -25,13 +25,16 @@ namespace Serilog.Sinks.Datadog.Logs
 
             var section = configurationSection.Get<DatadogConfiguration>();
 
+            // Proxy is code-only (IWebProxy cannot be bound from config); proxyUrl can come from config section.
             var result = new DatadogConfiguration(
                 url: datadogConfiguration?.Url ?? section.Url,
                 port: datadogConfiguration?.Port ?? section.Port,
                 useSSL: datadogConfiguration?.UseSSL ?? section.UseSSL,
                 useTCP: datadogConfiguration?.UseTCP ?? section.UseTCP,
-                maxRetries:datadogConfiguration?.MaxRetries ?? section.MaxRetries,
-                resolveHostIfMissing: datadogConfiguration?.ResolveHostIfMissing ?? section.ResolveHostIfMissing
+                maxRetries: datadogConfiguration?.MaxRetries ?? section.MaxRetries,
+                resolveHostIfMissing: datadogConfiguration?.ResolveHostIfMissing ?? section.ResolveHostIfMissing,
+                proxy: datadogConfiguration?.Proxy,
+                proxyUrl: datadogConfiguration?.ProxyUrl ?? section.ProxyUrl
             );
 
             return result;

--- a/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
+++ b/src/Serilog.Sinks.Datadog.Logs/Serilog.Sinks.Datadog.Logs.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;netstandard1.3;net45;net461;net472;net5.0</TargetFrameworks>

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogConfiguration.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogConfiguration.cs
@@ -1,7 +1,9 @@
-﻿// Unless explicitly stated otherwise all files in this repository are licensed
+// Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019 Datadog, Inc.
+
+using System.Net;
 
 namespace Serilog.Sinks.Datadog.Logs
 {
@@ -55,10 +57,22 @@ namespace Serilog.Sinks.Datadog.Logs
         /// </summary>
         public int MaxRetries { get; set; }
 
+        /// <summary>
+        /// Proxy to use for HTTP log submission. When set, all HTTP requests to the Datadog intake go through this proxy.
+        /// Compatible with Datadog agent proxy configuration (e.g. https://docs.datadoghq.com/agent/proxy/).
+        /// </summary>
+        public IWebProxy Proxy { get; set; }
+
+        /// <summary>
+        /// Proxy URL for HTTP log submission (e.g. "http://proxy.example.com:8080").
+        /// When set, a <see cref="WebProxy"/> is used for requests. Ignored if <see cref="Proxy"/> is set.
+        /// </summary>
+        public string ProxyUrl { get; set; }
+
         public DatadogConfiguration() : this(DDUrl, DDPort, true, false) {
         }
 
-        public DatadogConfiguration(string url = DDUrl, int port = DDPort, bool useSSL = true, bool useTCP = false, int maxRetries = 10, bool resolveHostIfMissing = false)
+        public DatadogConfiguration(string url = DDUrl, int port = DDPort, bool useSSL = true, bool useTCP = false, int maxRetries = 10, bool resolveHostIfMissing = false, IWebProxy proxy = null, string proxyUrl = null)
         {
             Url = url;
             Port = port;
@@ -66,6 +80,8 @@ namespace Serilog.Sinks.Datadog.Logs
             UseTCP = useTCP;
             MaxRetries = maxRetries;
             ResolveHostIfMissing = resolveHostIfMissing;
+            Proxy = proxy;
+            ProxyUrl = proxyUrl;
         }
 
         public override string ToString() => $"{{ Url: {Url}, Port: {Port}, UseSSL: {UseSSL}, UseTCP: {UseTCP} }}";

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpIntakeClient.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogHttpIntakeClient.cs
@@ -1,4 +1,4 @@
-﻿// Unless explicitly stated otherwise all files in this repository are licensed
+// Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019 Datadog, Inc.
@@ -10,6 +10,13 @@ namespace Serilog.Sinks.Datadog.Logs
     internal class DatadogHttpIntakeClient : HttpClient
     {
         public DatadogHttpIntakeClient(string apiKey)
+            : this(apiKey, null)
+        {
+        }
+
+        /// <param name="handler">Optional. When provided (e.g. HttpClientHandler with Proxy set), all requests use it. When null, default handler is used.</param>
+        public DatadogHttpIntakeClient(string apiKey, HttpMessageHandler handler)
+            : base(handler ?? new HttpClientHandler(), disposeHandler: true)
         {
             DefaultRequestHeaders.Add("DD-API-KEY", apiKey);
             DefaultRequestHeaders.Add("DD-EVP-ORIGIN", "Serilog.Sinks.Datadog.Logs");

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -1,4 +1,4 @@
-﻿// Unless explicitly stated otherwise all files in this repository are licensed
+// Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019 Datadog, Inc.
@@ -7,6 +7,8 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Net;
+using System.Net.Http;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Serilog.Core;
@@ -147,7 +149,15 @@ namespace Serilog.Sinks.Datadog.Logs
             }
             else
             {
-                var httpIntakeClient = new DatadogHttpIntakeClient(apiKey);
+                // When proxy is configured, use an HttpClientHandler so all HTTP intake requests go through it.
+                // Proxy (IWebProxy) takes precedence and ProxyUrl is converted to WebProxy when Proxy is not set.
+                HttpMessageHandler handler = null;
+                var proxy = configuration.Proxy ?? (string.IsNullOrWhiteSpace(configuration.ProxyUrl) ? null : new WebProxy(configuration.ProxyUrl));
+                if (proxy != null)
+                {
+                    handler = new HttpClientHandler { Proxy = proxy };
+                }
+                var httpIntakeClient = new DatadogHttpIntakeClient(apiKey, handler);
                 return new DatadogHttpClient($"{configuration.Url}/api/v2/logs", renderer, httpIntakeClient, configuration.MaxRetries);
             }
         }

--- a/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
+++ b/src/Serilog.Sinks.Datadog.Logs/Sinks/Datadog/DatadogSink.cs
@@ -149,14 +149,17 @@ namespace Serilog.Sinks.Datadog.Logs
             }
             else
             {
-                // When proxy is configured, use an HttpClientHandler so all HTTP intake requests go through it.
-                // Proxy (IWebProxy) takes precedence and ProxyUrl is converted to WebProxy when Proxy is not set.
                 HttpMessageHandler handler = null;
+#if NETSTANDARD2_0 || NET45 || NET461 || NET472 || NET5_0
+                // When proxy is configured, use an HttpClientHandler so all HTTP intake requests go through it.
+                // Proxy (IWebProxy) takes precedence; ProxyUrl is converted to WebProxy when Proxy is not set.
+                // netstandard1.3 does not have WebProxy/HttpClientHandler.Proxy; use custom client for proxy on that target.
                 var proxy = configuration.Proxy ?? (string.IsNullOrWhiteSpace(configuration.ProxyUrl) ? null : new WebProxy(configuration.ProxyUrl));
                 if (proxy != null)
                 {
                     handler = new HttpClientHandler { Proxy = proxy };
                 }
+#endif
                 var httpIntakeClient = new DatadogHttpIntakeClient(apiKey, handler);
                 return new DatadogHttpClient($"{configuration.Url}/api/v2/logs", renderer, httpIntakeClient, configuration.MaxRetries);
             }

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/ProxyConfigurationTests.cs
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/ProxyConfigurationTests.cs
@@ -1,0 +1,54 @@
+using System.Net;
+using NUnit.Framework;
+using Serilog;
+using Serilog.Sinks.Datadog.Logs;
+
+namespace Serilog.Sinks.Datadog.Logs.Tests
+{
+    [TestFixture]
+    public class ProxyConfigurationTests
+    {
+        [Test]
+        public void Sink_CanBeCreated_WithProxyUrl()
+        {
+            var config = new DatadogConfiguration(proxyUrl: "http://proxy.example.com:8080");
+            using (var log = new LoggerConfiguration()
+                .WriteTo.DatadogLogs("NOT_AN_API_KEY", configuration: config)
+                .CreateLogger())
+            {
+                Assert.IsNotNull(log);
+            }
+        }
+
+        [Test]
+        public void Sink_CanBeCreated_WithProxy()
+        {
+            var config = new DatadogConfiguration();
+            config.Proxy = new WebProxy("http://proxy.example.com:8080");
+            using (var log = new LoggerConfiguration()
+                .WriteTo.DatadogLogs("NOT_AN_API_KEY", configuration: config)
+                .CreateLogger())
+            {
+                Assert.IsNotNull(log);
+            }
+        }
+
+        [Test]
+        public void Sink_WithProxyUrl_AndCustomClient_LogsSuccessfully()
+        {
+            var config = new DatadogConfiguration(proxyUrl: "http://proxy.example.com:8080");
+            var renderer = new DatadogLogRenderer("src", "svc", "host", null, 256 * 1000, new DatadogJsonFormatter());
+            var noop = new NoopClient("NOT_AN_API_KEY", renderer);
+
+            using (var log = new LoggerConfiguration()
+                .WriteTo.DatadogLogs("NOT_AN_API_KEY", configuration: config, client: noop)
+                .CreateLogger())
+            {
+                log.Information("hello via proxy config");
+            }
+
+            Assert.AreEqual(1, noop.SentPayloads.Count);
+            StringAssert.Contains("hello via proxy config", noop.SentPayloads[0]);
+        }
+    }
+}

--- a/tests/Serilog.Sinks.Datadog.Logs.Tests/Serilog.Sinks.Datadog.Logs.Tests.csproj
+++ b/tests/Serilog.Sinks.Datadog.Logs.Tests/Serilog.Sinks.Datadog.Logs.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net10.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>..\..\Serilog.Sinks.Datadog.Logs.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>


### PR DESCRIPTION
### What does this PR do?
Addresses [issue 62](https://github.com/DataDog/serilog-sinks-datadog-logs/issues/62), [AGNTLOG-430](https://datadoghq.atlassian.net/browse/AGNTLOG-430), and [TEEP-5134](https://datadoghq.atlassian.net/browse/TEEP-5134)

Adds proxy support for HTTP log submission in the Serilog Datadog logs sink.

- DatadogConfiguration.Proxy (IWebProxy): use any .NET proxy (e.g. credentials, bypass list).
- DatadogConfiguration.ProxyUrl (string) like "http://proxy.example.com:8080"; can be set in code or via appsettings.
- When either is set, the default HTTP client is created with an HttpClientHandler that uses that proxy, so all requests to the Datadog HTTP intake go through the proxy.
- DatadogHttpIntakeClient gains an overload that accepts an optional HttpMessageHandler (used when a proxy is configured).
- Configuration binding (e.g. appsettings.json) merges proxyUrl from the config section so proxy can be configured without code changes.
- README documents proxy usage and mentions the third-party Serilog.Sinks.Datadog.Logs.WithProxy package and CHANGELOG updated for 0.6.2.
- Resolves #62.

### Motivation
Customers need to send logs through an HTTP proxy (e.g. to match Datadog agent proxy configuration or corporate proxies). The sink had no built-in proxy support and workarounds were system-level proxy env vars, web.config, or manually building an HttpClient with a custom handler and passing it via the existing client parameter. This PR adds a supported, documented way to configure proxy via DatadogConfiguration so users don’t need those workarounds or a third-party package.

### How I validated my changes
Unit tests (ProxyConfigurationTests.cs):
- Sink can be created with ProxyUrl and no custom client (exercises the HTTP client creation path with proxy).
- Sink can be created with Proxy (IWebProxy).
- With proxy config and a custom client (NoopClient), logging still works and the client receives the payload.

Linting: No new linter issues in the changed files.
Manual review: Confirmed proxy resolution (Proxy vs ProxyUrl), handler creation only when proxy is set, and config merge for proxyUrl in ApplyMicrosoftExtensionsConfiguration.
I did not run a full dotnet test or live proxy test in this environment due to sandbox/network limits (Next step for me)

[AGNTLOG-430]: https://datadoghq.atlassian.net/browse/AGNTLOG-430?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TEEP-5134]: https://datadoghq.atlassian.net/browse/TEEP-5134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ