### PR TITLE
[ACIX-1926] chore(ci): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -25,11 +25,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -38,7 +38,7 @@ jobs:
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88 # v2.28.1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,9 +12,9 @@ jobs:
           - '6.0.x'
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@a37ce9120846195fa4ece8f58b268e6043cb2f26 # v3.7.0
       - name: Setup .NET Core SDK ${{ matrix.dotnet-version }}
-        uses: actions/setup-dotnet@v3
+        uses: actions/setup-dotnet@55ec9447dda3d1cf6bd587150f3262f30ee10815 # v3.4.2
         with:
           dotnet-version: ${{ matrix.dotnet-version }}
       - name: Install dependencies


### PR DESCRIPTION
Mechanical rewrite of every `uses:` reference to a full-length commit SHA, produced by [pinact](https://github.com/suzuki-shunsuke/pinact). An unpinned reference resolves to a mutable ref, so a compromise of the upstream action becomes code execution in this repository's CI.

The trailing `# vX.Y.Z` comment is what lets Renovate and Dependabot keep these bumped, so please keep it.

**One thing to check:** references that tracked `@main` or `@master` were resolved to the latest stable tag. If any of them floated deliberately and that behaviour was load-bearing here, say so on the PR and we will revert that line.
